### PR TITLE
fix: vite alias config

### DIFF
--- a/template/base/vite.config.js
+++ b/template/base/vite.config.js
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      '@/': new URL('./src/', import.meta.url).pathname
+      '@': path.resolve(__dirname,'src')
     }
   }
 })


### PR DESCRIPTION
**Description**
The vite alias parsing error occurs when the root path contains Chinese, but is correct when there is no Chinese
The file path is as follows
--项目
   --create-project
       --files
![image](https://user-images.githubusercontent.com/45839282/138673282-911bb789-ff0b-4f68-9593-d01130f344e8.png)
