### PR TITLE
fix: use string as prop type in TS

### DIFF
--- a/playground/typescript-jsx-router-vuex-with-tests/src/components/HelloWorld.vue
+++ b/playground/typescript-jsx-router-vuex-with-tests/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-jsx-router-vuex/src/components/HelloWorld.vue
+++ b/playground/typescript-jsx-router-vuex/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-jsx-router-with-tests/src/components/HelloWorld.vue
+++ b/playground/typescript-jsx-router-with-tests/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-jsx-router/src/components/HelloWorld.vue
+++ b/playground/typescript-jsx-router/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-jsx-vuex-with-tests/src/components/HelloWorld.vue
+++ b/playground/typescript-jsx-vuex-with-tests/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-jsx-vuex/src/components/HelloWorld.vue
+++ b/playground/typescript-jsx-vuex/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-jsx-with-tests/src/components/HelloWorld.vue
+++ b/playground/typescript-jsx-with-tests/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-jsx/src/components/HelloWorld.vue
+++ b/playground/typescript-jsx/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-router-vuex-with-tests/src/components/HelloWorld.vue
+++ b/playground/typescript-router-vuex-with-tests/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-router-vuex/src/components/HelloWorld.vue
+++ b/playground/typescript-router-vuex/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-router-with-tests/src/components/HelloWorld.vue
+++ b/playground/typescript-router-with-tests/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-router/src/components/HelloWorld.vue
+++ b/playground/typescript-router/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-vuex-with-tests/src/components/HelloWorld.vue
+++ b/playground/typescript-vuex-with-tests/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-vuex/src/components/HelloWorld.vue
+++ b/playground/typescript-vuex/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript-with-tests/src/components/HelloWorld.vue
+++ b/playground/typescript-with-tests/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/playground/typescript/src/components/HelloWorld.vue
+++ b/playground/typescript/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/template/code/typescript-default/src/components/HelloWorld.vue
+++ b/template/code/typescript-default/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 

--- a/template/code/typescript-router/src/components/HelloWorld.vue
+++ b/template/code/typescript-router/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  msg: String
+  msg: string
 }>()
 </script>
 


### PR DESCRIPTION
The `HelloWorld` component was using `String` as a type instead of `string`.