### PR TITLE
fix(template): update gitignore to include extensions.json

### DIFF
--- a/template/base/_gitignore
+++ b/template/base/_gitignore
@@ -17,7 +17,7 @@ dist-ssr
 /cypress/screenshots/
 
 # Editor directories and files
-.vscode
+.vscode/*
 !.vscode/extensions.json
 .idea
 *.suo


### PR DESCRIPTION
`.gitignore` had `.vscode`, with this config vscode ignores whole `.vscode` directory including `extensions.json`.

Updated to `.vscode/*` so it allows excluding files via `!` prefix.