### PR TITLE
fix: eslint with prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,7 +261,7 @@ async function init() {
   }
 
   if (needsEslint) {
-    renderEslint(root, result)
+    renderEslint(root, { needsTypeScript, needsTests, needsPrettier })
   }
 
   // Render code template.


### PR DESCRIPTION
The eslint script currently ignores the typescript, test, and prettier flags.