### PR TITLE
chore: add `declare module "*.vue"` to "env.d.ts"

### DIFF
--- a/template/config/typescript/env.d.ts
+++ b/template/config/typescript/env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import { DefineComponent } from 'vue'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}


### PR DESCRIPTION
Added `declare module "*.vue"` as in create-vite/template-vue-ts in vite. <https://github.com/vitejs/vite/blob/main/packages/create-vite/template-vue-ts/src/env.d.ts>

If there are any problems, please close this PR. 🙇