### PR TITLE
feat: add format command by prettier

### DIFF
--- a/utils/renderEslint.js
+++ b/utils/renderEslint.js
@@ -90,7 +90,8 @@ export default function renderEslint(
         // Note that we reuse .gitignore here to avoid duplicating the configuration
         lint: needsTypeScript
           ? 'eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore'
-          : 'eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore'
+          : 'eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore',
+        format: needsPrettier ? 'prettier --write .' : undefined
       },
       devDependencies: dependencies
     })


### PR DESCRIPTION
If project is configured to use Prettier, configure it to be able to call prettier with the `npm run format` command.