### PR TITLE
chore: add coverage to gitignore

### DIFF
--- a/template/base/_gitignore
+++ b/template/base/_gitignore
@@ -11,6 +11,7 @@ node_modules
 .DS_Store
 dist
 dist-ssr
+coverage
 *.local
 
 /cypress/videos/


### PR DESCRIPTION
`vitest` (`c8` to be more accurate)  outputs the coverage results in a `coverage` directory by default.