### PR TITLE
fix: fix packageName when npm init vue set valid targetDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,7 +227,7 @@ async function init() {
   // so we still have to assign the default values here
   const {
     projectName,
-    packageName = projectName,
+    packageName = projectName || defaultProjectName,
     shouldOverwrite = argv.force,
     needsJsx = argv.jsx,
     needsTypeScript = argv.typescript,


### PR DESCRIPTION
Fix package.json dosen't generate `name` when npm init vue set valid targetDir