### PR TITLE
fix: vitest tsconfig should include all files under `src`

### DIFF
--- a/template/tsconfig/vitest/package.json
+++ b/template/tsconfig/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "typecheck": "vue-tsc --noEmit && vue-tsc --noEmit -p tsconfig.vitest.json --composite false"
+    "typecheck": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false"
   },
   "devDependencies": {
     "@types/jsdom": "^16.2.14"

--- a/template/tsconfig/vitest/tsconfig.app.json
+++ b/template/tsconfig/vitest/tsconfig.app.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.web.json",
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
+  "exclude": ["src/**/__tests__/*"],
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/template/tsconfig/vitest/tsconfig.json
+++ b/template/tsconfig/vitest/tsconfig.json
@@ -1,17 +1,11 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.web.json",
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
-  "exclude": ["src/**/__tests__/*"],
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  },
-
+  "files": [],
   "references": [
     {
       "path": "./tsconfig.vite-config.json"
+    },
+    {
+      "path": "./tsconfig.app.json"
     },
     {
       "path": "./tsconfig.vitest.json"

--- a/template/tsconfig/vitest/tsconfig.vitest.json
+++ b/template/tsconfig/vitest/tsconfig.vitest.json
@@ -1,12 +1,9 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.node.json",
-  "include": ["src/**/__tests__/*"],
+  "extends": "./tsconfig.app.json",
+  "exclude": [],
   "compilerOptions": {
     "composite": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
-    "types": ["node", "jsdom"]
+    "lib": [],
+    "types": ["node", "vitest"]
   }
 }

--- a/template/tsconfig/vitest/tsconfig.vitest.json
+++ b/template/tsconfig/vitest/tsconfig.vitest.json
@@ -4,6 +4,6 @@
   "compilerOptions": {
     "composite": true,
     "lib": [],
-    "types": ["node", "vitest"]
+    "types": ["node", "jsdom"]
   }
 }


### PR DESCRIPTION
Credit to @xiaoxiangmoe 

Fixes #55

Fixes the case that a `.spec.ts` file inside `__test__/` imports a
module outside of `__test__/` (a cross-(typescript-)project reference).

Note that VSCode language service looks for `include` patterns in `references`
top-down, so `tsconfig.app.json` must come before `tsconfig.vitest.json`
so that the `src/**` modules can get the most-accurate type hints.

The previous tsconfig only works for `.vue` imports in `.spec.ts`, which
seems to be a Volar bug. We shouldn't rely on that.
This fix is a more accurate configuration.

Vitest TypeScript projects created prior to `create-vue` 3.1.6 can apply the following patch to the projects:

```patch
From a37c33facf0e5db767bee33a71ad9e9fcd3cf373 Mon Sep 17 00:00:00 2001
From: Haoqun Jiang <haoqunjiang@gmail.com>
Date: Tue, 15 Feb 2022 21:50:07 +0800
Subject: [PATCH] fix: vitest tsconfig

---
 package.json         |  2 +-
 tsconfig.app.json    | 12 ++++++++++++
 tsconfig.json        | 14 ++++----------
 tsconfig.vitest.json |  9 +++------
 4 files changed, 20 insertions(+), 17 deletions(-)
 create mode 100644 tsconfig.app.json

diff --git a/package.json b/package.json
index ad9e16d..5138df6 100644
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview --port 5050",
     "test:unit": "vitest --environment jsdom",
-    "typecheck": "vue-tsc --noEmit && vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
+    "typecheck": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
   },
   "dependencies": {
diff --git a/tsconfig.app.json b/tsconfig.app.json
new file mode 100644
index 0000000..cdbea1d
--- /dev/null
+++ b/tsconfig.app.json
@@ -0,0 +1,12 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.web.json",
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
+  "exclude": ["src/**/__tests__/*"],
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
diff --git a/tsconfig.json b/tsconfig.json
index 2551bf2..24f21b0 100644
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,12 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.web.json",
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
-  "exclude": ["src/**/__tests__/*"],
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  },
-
+  "files": [],
   "references": [
     {
       "path": "./tsconfig.vite-config.json"
     },
+    {
+      "path": "./tsconfig.app.json"
+    },
     {
       "path": "./tsconfig.vitest.json"
     }
diff --git a/tsconfig.vitest.json b/tsconfig.vitest.json
index 5667568..d080d61 100644
--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,12 +1,9 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.node.json",
-  "include": ["src/**/__tests__/*"],
+  "extends": "./tsconfig.app.json",
+  "exclude": [],
   "compilerOptions": {
     "composite": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
+    "lib": [],
     "types": ["node", "jsdom"]
   }
 }
-- 
2.35.1

```