### PR TITLE
fix(template): removed old volar extension

### DIFF
--- a/template/base/.vscode/extensions.json
+++ b/template/base/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["johnsoncodehk.volar", "johnsoncodehk.vscode-typescript-vue-plugin"]
+  "recommendations": ["johnsoncodehk.volar"]
 }


### PR DESCRIPTION
Removed "johnsoncodehk.vscode-typescript-vue-plugin" for extension recommendation.

As per [this](https://discord.com/channels/793943652350427136/793943652350427139/894949633267232778) chat, I think "johnsoncodehk.vscode-typescript-vue-plugin" extension is no longer needed.

Am I right, @johnsoncodehk?