### PR TITLE
Add missing vue module definition

### DIFF
--- a/template/config/typescript/env.d.ts
+++ b/template/config/typescript/env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}


### PR DESCRIPTION
Right now if you import a .vue file inside of a .ts file (e.g. router/index.ts) you get this error:

<img width="945" alt="image" src="https://user-images.githubusercontent.com/5460365/155032613-f8c9a3b7-1da6-40e7-9a23-616c65090fee.png">

To fix this you only need to add this module definition for the .vue files into the `env.d.ts` file

```ts
declare module '*.vue' {
  import type { DefineComponent } from 'vue'
  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
  const component: DefineComponent<{}, {}, any>
  export default component
}
```