### PR TITLE
fix: support node v12

### DIFF
--- a/index.js
+++ b/index.js
@@ -373,7 +373,7 @@ async function init() {
   // Supported package managers: pnpm > yarn > npm
   // Note: until <https://github.com/pnpm/pnpm/issues/3505> is resolved,
   // it is not possible to tell if the command is called by `pnpm init`.
-  const userAgent = process.env.npm_config_user_agent ?? ''
+  const userAgent = process.env.npm_config_user_agent || ''
   const packageManager = /pnpm/.test(userAgent) ? 'pnpm' : /yarn/.test(userAgent) ? 'yarn' : 'npm'
 
   // README generation


### PR DESCRIPTION
我看了之前的提交 [chore!: have to drop Node.js 12 (again)](https://github.com/zhhbstudio/create-vue/commit/cea1dcc1b1b4e7a33bea0db9a4febae88bae626a)，但是还是想提这次 pr，理由如下：

1. 当前 node v12 的 **（服务）终止日期** 是 [2022-04-30](https://nodejs.org/en/about/releases/)
2. [部分代码](https://github.com/vuejs/create-vue/blob/8ad42c20ed7c98413e31f6e6dabc48dff06b068a/index.js#L74) 还是兼容 node v12 的
3. 我们是否不应该因为第三方不支持而影响不依赖第三方的部分也不支持（部分项目可能用不到 typescript）

#73 