### PR TITLE
feat: add standard and airbnb styleguide of eslint

### DIFF
--- a/template/eslint/package.json
+++ b/template/eslint/package.json
@@ -6,6 +6,12 @@
     "eslint": "^8.5.0",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-vue": "^8.2.0",
+    "@vue/eslint-config-airbnb": "^6.0.0",
+    "eslint-plugin-vuejs-accessibility": "^1.1.0",
+    "@vue/eslint-config-standard": "^6.1.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^6.0.0",
     "prettier": "^2.5.1"
   }
 }

--- a/utils/renderEslint.ts
+++ b/utils/renderEslint.ts
@@ -27,18 +27,27 @@ const config: ESLintConfig = {
 }
 
 function configureEslint({ language, styleGuide, needsPrettier, needsCypress, needsCypressCT }) {
-  switch (`${styleGuide}-${language}`) {
-    case 'default-javascript':
+  switch (`${styleGuide}`) {
+    case 'default':
       config.extends.push('eslint:recommended')
       break
-    case 'default-typescript':
-      addEslintDependency('@vue/eslint-config-typescript')
-      config.extends.push('eslint:recommended')
-      config.extends.push('@vue/eslint-config-typescript/recommended')
+    case 'standard':
+      config.extends.push('@vue/standard')
+      addEslintDependency('@vue/eslint-config-standard')
+      addEslintDependency('eslint-plugin-import')
+      addEslintDependency('eslint-plugin-node')
+      addEslintDependency('eslint-plugin-promise')
       break
-    // TODO: airbnb and standard
+    case 'airbnb':
+      config.extends.push('@vue/airbnb')
+      addEslintDependency('eslint-plugin-vuejs-accessibility')
+      addEslintDependency('eslint-plugin-import')
+      break
   }
-
+  if (language == 'typescript') {
+    config.extends.push('@vue/eslint-config-typescript/recommended')
+    addEslintDependency('@vue/eslint-config-typescript')
+  }
   if (needsPrettier) {
     addEslintDependency('prettier')
     addEslintDependency('@vue/eslint-config-prettier')
@@ -75,12 +84,12 @@ function configureEslint({ language, styleGuide, needsPrettier, needsCypress, ne
 
 export default function renderEslint(
   rootDir,
-  { needsTypeScript, needsCypress, needsCypressCT, needsPrettier }
+  { needsTypeScript, needsCypress, needsCypressCT, needsPrettier, eslintStyle }
 ) {
   const { dependencies, configuration } = configureEslint({
     language: needsTypeScript ? 'typescript' : 'javascript',
     // we currently don't support other style guides
-    styleGuide: 'default',
+    styleGuide: eslintStyle,
     needsPrettier,
     needsCypress,
     needsCypressCT


### PR DESCRIPTION
add standard and airbnb styleguide of eslint.

the version of "@vue/eslint-config-standard" and "@vue/eslint-config-airnbnb" in template/eslint/package.json may need to change because the eslint-plugin-import need the resolver of vite, and these two pr nees to be solved at before:

[add vite support for @vue/eslint-config-standard](https://github.com/vuejs/eslint-config-standard/pull/17)
[add vite support for @vue/eslint-config-airbnb](https://github.com/vuejs/eslint-config-airbnb/pull/45)