### PR TITLE
fix: update `vue-template-babel-compiler`

### DIFF
--- a/template/base/package.json
+++ b/template/base/package.json
@@ -14,7 +14,7 @@
     "unplugin-vue2-script-setup": "^0.9.3",
     "vite": "^2.8.4",
     "vite-plugin-vue2": "^1.9.3",
-    "vue-template-babel-compiler": "1.1.3",
+    "vue-template-babel-compiler": "^1.2.0",
     "vue-template-compiler": "^2.6.14"
   }
 }


### PR DESCRIPTION
Updates `vue-template-babel-compiler` in order to get the fixes from https://github.com/JuniorTour/vue-template-babel-compiler/pull/40 to resolve dependency issues in the project generated by `yarn create vue@2`.