### PR TITLE
feat: add jsconfig.json for base template

### DIFF
--- a/template/base/jsconfig.json
+++ b/template/base/jsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/template/base/jsconfig.json
+++ b/template/base/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/template/base/jsconfig.json
+++ b/template/base/jsconfig.json
@@ -3,5 +3,6 @@
     "paths": {
       "@/*": ["./src/*"]
     }
-  }
+  },
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Create-vue doesn't create a `jsconfig.json` file on the first initialization without TS. Added `jsconfig.json` with aliased paths to base template for out of the box VSCode IntelliSense