### PR TITLE
fix: resolve lint warnings in scaffold

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -314,6 +314,9 @@ async function init() {
   if (needsEslint) {
     renderEslint(root, { needsTypeScript, needsCypress, needsCypressCT, needsPrettier })
   }
+  if (needsPrettier) {
+    render('config/prettier')
+  }
 
   // Render code template.
   // prettier-ignore

--- a/template/config/prettier/.prettierrc
+++ b/template/config/prettier/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "printWidth": 100,
+  "trailingComma": "none"
+}

--- a/utils/renderEslint.ts
+++ b/utils/renderEslint.ts
@@ -62,7 +62,12 @@ function configureEslint({ language, styleGuide, needsPrettier, needsCypress, ne
     addEslintDependency('@rushstack/eslint-patch')
     configuration += `require("@rushstack/eslint-patch/modern-module-resolution");\n\n`
   }
-  configuration += `module.exports = ${JSON.stringify(config, undefined, 2)}\n`
+  const configString = JSON.stringify(config, undefined, 2)
+    // remove quotes from the object keys (keep escaped quotes)
+    .replace(/\\"/g, '\uFFFF')
+    .replace(/"([^"]+)":/g, '$1:')
+    .replace(/\uFFFF/g, '\\"')
+  configuration += `module.exports = ${configString}\n`
 
   return {
     dependencies,


### PR DESCRIPTION
Changes:

 * Scaffolds `.prettierrc` if Prettier is selected at prompt
 * Removes quotes from config object's keys in scaffolded `.eslintrc.cjs`

fix #116 