### PR TITLE
perf: exclude transpiled prompts code

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -33,6 +33,16 @@ await esbuild.build({
   target: 'node14',
 
   plugins: [
+    {
+      name: 'alias',
+      setup({ onResolve, resolve }) {
+        onResolve({ filter: /^prompts$/, namespace: 'file' }, async ({ importer, resolveDir }) => {
+          // we can always use non-transpiled code since we support 14.16.0+
+          const result = await resolve('prompts/lib/index.js', { importer, resolveDir })
+          return result
+        })
+      }
+    },
     esbuildPluginLicense({
       thirdParty: {
         includePrivate: false,


### PR DESCRIPTION
Since this package supports Node 14+, the transpiled `prompts` code is not used.
https://github.com/terkelg/prompts/blob/a0c1777ae86d04e46cb42eb3af69ca74ae5d79e2/index.js#L11-L14
This PR removes that from bundle.

|                        | before     | after         |         diff |
|----------------|-----------:|-----------:|----------:|
|gz                    | 53,746B   | 39,690B   | -14,056B (-26.2%) |
|node_modules| 319,900B | 232,067B | -87,833B (-27.5%) |
