### PR TITLE
fix: 🐛 Vue already exists in production dependency

### DIFF
--- a/template/config/jsx/package.json
+++ b/template/config/jsx/package.json
@@ -1,7 +1,6 @@
 {
   "devDependencies": {
     "@vitejs/plugin-vue-jsx": "^2.0.0",
-    "vite": "^3.0.1",
-    "vue": "^3.2.37"
+    "vite": "^3.0.1"
   }
 }


### PR DESCRIPTION
Vue already exists in production dependency