### PR TITLE
tsconfig.vite.ts should include only the test files

### DIFF
--- a/template/tsconfig/vitest/tsconfig.vitest.json
+++ b/template/tsconfig/vitest/tsconfig.vitest.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.app.json",
+  "include": ["src/**/__tests__/*"],
   "exclude": [],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
Otherwise node and jsdom types are available in ts and vue files. Whoops.