### PR TITLE
fix: remove console.log

### DIFF
--- a/utils/renderEslint.ts
+++ b/utils/renderEslint.ts
@@ -58,7 +58,6 @@ export default function renderEslint(
   // write to .eslintrc.cjs, .prettierrc.json, etc.
   for (const [fileName, content] of Object.entries(files)) {
     const fullPath = path.resolve(rootDir, fileName)
-    console.log(fullPath, content)
     fs.writeFileSync(fullPath, content as string, 'utf-8')
   }
 }


### PR DESCRIPTION
The ESLint config is currently logged out when a new project is generated.