### PR TITLE
refactor!: use prod bundle & preview server for playwright testing on CI

### DIFF
--- a/template/base/package.json
+++ b/template/base/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 4173"
+    "preview": "vite preview"
   },
   "dependencies": {
     "vue": "^3.2.40"

--- a/template/config/playwright/playwright.config.js
+++ b/template/config/playwright/playwright.config.js
@@ -35,7 +35,7 @@ const config = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:5173',
+    baseURL: 'http://localhost:4173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -99,8 +99,8 @@ const config = {
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
-    port: 5173,
+    command: 'npm run preview',
+    port: 4173,
     reuseExistingServer: !process.env.CI
   }
 }

--- a/template/config/playwright/playwright.config.js
+++ b/template/config/playwright/playwright.config.js
@@ -103,7 +103,7 @@ const config = {
      * Use the dev server by default for faster feedback loop.
      * Use the preview server on CI for more realistic testing.
      */
-    command: process.env.CI ? 'npm run preview -- --port 5173' : 'npm run dev',
+    command: process.env.CI ? 'vite preview --port 5173' : 'vite dev',
     port: 5173,
     reuseExistingServer: !process.env.CI
   }

--- a/template/config/playwright/playwright.config.js
+++ b/template/config/playwright/playwright.config.js
@@ -103,7 +103,7 @@ const config = {
      * Use the dev server by default for faster feedback loop.
      * Use the preview server on CI for more realistic testing.
      */
-    command: process.env.CI ? 'npm run preview --port 5173' : 'npm run dev',
+    command: process.env.CI ? 'npm run preview -- --port 5173' : 'npm run dev',
     port: 5173,
     reuseExistingServer: !process.env.CI
   }

--- a/template/config/playwright/playwright.config.js
+++ b/template/config/playwright/playwright.config.js
@@ -35,7 +35,7 @@ const config = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:4173',
+    baseURL: 'http://localhost:5173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -99,8 +99,12 @@ const config = {
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run preview',
-    port: 4173,
+    /**
+     * Use the dev server by default for faster feedback loop.
+     * Use the preview server on CI for more realistic testing.
+     */
+    command: process.env.CI ? 'npm run preview --port 5173' : 'npm run dev',
+    port: 5173,
     reuseExistingServer: !process.env.CI
   }
 }

--- a/template/config/playwright/playwright.config.ts
+++ b/template/config/playwright/playwright.config.ts
@@ -102,7 +102,7 @@ const config: PlaywrightTestConfig = {
      * Use the dev server by default for faster feedback loop.
      * Use the preview server on CI for more realistic testing.
      */
-    command: process.env.CI ? 'npm run preview --port 5173' : 'npm run dev',
+    command: process.env.CI ? 'npm run preview -- --port 5173' : 'npm run dev',
     port: 5173,
     reuseExistingServer: !process.env.CI
   }

--- a/template/config/playwright/playwright.config.ts
+++ b/template/config/playwright/playwright.config.ts
@@ -102,7 +102,7 @@ const config: PlaywrightTestConfig = {
      * Use the dev server by default for faster feedback loop.
      * Use the preview server on CI for more realistic testing.
      */
-    command: process.env.CI ? 'npm run preview -- --port 5173' : 'npm run dev',
+    command: process.env.CI ? 'vite preview --port 5173' : 'vite dev',
     port: 5173,
     reuseExistingServer: !process.env.CI
   }

--- a/template/config/playwright/playwright.config.ts
+++ b/template/config/playwright/playwright.config.ts
@@ -34,7 +34,7 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:5173',
+    baseURL: 'http://localhost:4173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -98,8 +98,8 @@ const config: PlaywrightTestConfig = {
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
-    port: 5173,
+    command: 'npm run preview',
+    port: 4173,
     reuseExistingServer: !process.env.CI
   }
 }

--- a/template/config/playwright/playwright.config.ts
+++ b/template/config/playwright/playwright.config.ts
@@ -101,6 +101,7 @@ const config: PlaywrightTestConfig = {
     /**
      * Use the dev server by default for faster feedback loop.
      * Use the preview server on CI for more realistic testing.
+    Playwright will re-use the local server if there is already a dev-server running.
      */
     command: process.env.CI ? 'vite preview --port 5173' : 'vite dev',
     port: 5173,

--- a/template/config/playwright/playwright.config.ts
+++ b/template/config/playwright/playwright.config.ts
@@ -34,7 +34,7 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:4173',
+    baseURL: 'http://localhost:5173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -98,8 +98,12 @@ const config: PlaywrightTestConfig = {
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run preview',
-    port: 4173,
+    /**
+     * Use the dev server by default for faster feedback loop.
+     * Use the preview server on CI for more realistic testing.
+     */
+    command: process.env.CI ? 'npm run preview --port 5173' : 'npm run dev',
+    port: 5173,
     reuseExistingServer: !process.env.CI
   }
 }

--- a/utils/generateReadme.ts
+++ b/utils/generateReadme.ts
@@ -99,7 +99,7 @@ ${commandFor('test:e2e')} # or \`${commandFor('test:e2e:ci')}\` for headless tes
 # Install browsers for the first run
 npx playwright install
 
-# Must build the project before end-to-end testing
+# When testing on CI, must build the project first
 ${commandFor('build')}
 
 # Runs the end-to-end tests

--- a/utils/generateReadme.ts
+++ b/utils/generateReadme.ts
@@ -25,7 +25,8 @@ export default function generateReadme({
   needsVitest,
   needsEslint
 }) {
-  const commandFor = (scriptName) => getCommand(packageManager, scriptName)
+  const commandFor = (scriptName: string, args?: string) =>
+    getCommand(packageManager, scriptName, args)
 
   let readme = `# ${projectName}
 
@@ -105,11 +106,11 @@ ${commandFor('build')}
 # Runs the end-to-end tests
 ${commandFor('test:e2e')}
 # Runs the tests only on Chromium
-${commandFor('test:e2e -- --project=chromium')}
+${commandFor('test:e2e', '--project=chromium')}
 # Runs the tests of a specific file
-${commandFor('test:e2e -- tests/example.spec.ts')}
+${commandFor('test:e2e', 'tests/example.spec.ts')}
 # Runs the tests in debug mode
-${commandFor('test:e2e -- --debug')}
+${commandFor('test:e2e', '--debug')}
 \`\`\`
 `
   }

--- a/utils/generateReadme.ts
+++ b/utils/generateReadme.ts
@@ -99,6 +99,9 @@ ${commandFor('test:e2e')} # or \`${commandFor('test:e2e:ci')}\` for headless tes
 # Install browsers for the first run
 npx playwright install
 
+# Must build the project before end-to-end testing
+${commandFor('build')}
+
 # Runs the end-to-end tests
 ${commandFor('test:e2e')}
 # Runs the tests only on Chromium

--- a/utils/getCommand.ts
+++ b/utils/getCommand.ts
@@ -1,7 +1,13 @@
-export default function getCommand(packageManager, scriptName) {
+export default function getCommand(packageManager: string, scriptName: string, args?: string) {
   if (scriptName === 'install') {
     return packageManager === 'yarn' ? 'yarn' : `${packageManager} install`
   }
 
-  return packageManager === 'npm' ? `npm run ${scriptName}` : `${packageManager} ${scriptName}`
+  if (args) {
+    return packageManager === 'npm'
+      ? `npm run ${scriptName} -- ${args}`
+      : `${packageManager} ${scriptName} ${args}`
+  } else {
+    return packageManager === 'npm' ? `npm run ${scriptName}` : `${packageManager} ${scriptName}`
+  }
 }


### PR DESCRIPTION
To make it consistent with the Cypress configurations.

Background: https://twitter.com/haoqunjiang/status/1582692547188920322

Alternative: use `npm run dev` in Cypress configuration, as suggested in https://github.com/vuejs/create-vue/pull/39