### PR TITLE
fix: typo in `needsE2eTesting` `choices` params

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -209,11 +209,11 @@ async function init() {
           type: () => (isFeatureFlagsUsed ? null : 'select'),
           message: 'Add an End-to-End Testing Solution?',
           initial: 0,
-          choices: (prev, anwsers) => [
+          choices: (prev, answers) => [
             { title: 'No', value: false },
             {
               title: 'Cypress',
-              description: anwsers.needsVitest
+              description: answers.needsVitest
                 ? undefined
                 : 'also supports unit testing with Cypress Component Testing',
               value: 'cypress'


### PR DESCRIPTION
Fix the typo in the new 3.4.0 E2E testing choices