### PR TITLE
fix: stringify targetDir if present

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -98,6 +98,9 @@ async function init() {
     ) === 'boolean'
 
   let targetDir = argv._[0]
+  if (targetDir !== undefined) {
+    targetDir = String(argv._[0])
+  }
   const defaultProjectName = !targetDir ? 'vue-project' : targetDir
 
   const forceOverwrite = argv.force


### PR DESCRIPTION
Fix #201 

The targetDir retrieved from `minimist` may be an number, and nodejs `path.join` does not accept number as argument.