### PR TITLE
fix: project name with only numbers as an argument (#201)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -78,6 +78,7 @@ async function init() {
       'with-tests': ['tests'],
       router: ['vue-router']
     },
+    string: ['_'],
     // all arguments are treated as booleans
     boolean: true
   })


### PR DESCRIPTION
Supersedes #202

Use a `string` option of `minimist` to stringify the potential numeric project name.
