### PR TITLE
feat: add eslint-config-airbnb

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -95,7 +95,8 @@ async function init() {
       argv.vitest ??
       argv.cypress ??
       argv.playwright ??
-      argv.eslint
+      argv.eslint ??
+      argv.eslintAirbnb
     ) === 'boolean'
 
   let targetDir = argv._[0]
@@ -114,6 +115,7 @@ async function init() {
     needsVitest?: boolean
     needsE2eTesting?: false | 'cypress' | 'playwright'
     needsEslint?: boolean
+    needsEslintAirbnb?: boolean
     needsPrettier?: boolean
   } = {}
 
@@ -234,6 +236,19 @@ async function init() {
           inactive: 'No'
         },
         {
+          name: 'needsEslintAirbnb',
+          type: (prev, values) => {
+            if (isFeatureFlagsUsed || !values.needsEslint) {
+              return null
+            }
+            return 'toggle'
+          },
+          message: 'Add ESLint airbnb rules?',
+          initial: false,
+          active: 'Yes',
+          inactive: 'No'
+        },
+        {
           name: 'needsPrettier',
           type: (prev, values) => {
             if (isFeatureFlagsUsed || !values.needsEslint) {
@@ -270,6 +285,7 @@ async function init() {
     needsPinia = argv.pinia,
     needsVitest = argv.vitest || argv.tests,
     needsEslint = argv.eslint || argv['eslint-with-prettier'],
+    needsEslintAirbnb = argv.eslintAirbnb,
     needsPrettier = argv['eslint-with-prettier']
   } = result
 
@@ -347,7 +363,13 @@ async function init() {
 
   // Render ESLint config
   if (needsEslint) {
-    renderEslint(root, { needsTypeScript, needsCypress, needsCypressCT, needsPrettier })
+    renderEslint(root, {
+      needsTypeScript,
+      needsCypress,
+      needsCypressCT,
+      needsPrettier,
+      needsEslintAirbnb
+    })
   }
 
   // Render code template.

--- a/template/eslint/package.json
+++ b/template/eslint/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
-    "eslint-plugin-cypress": "^2.12.1"
+    "eslint-plugin-cypress": "^2.12.1",
+    "@vue/eslint-config-airbnb": "^7.0.0"
   }
 }

--- a/utils/renderEslint.ts
+++ b/utils/renderEslint.ts
@@ -11,7 +11,7 @@ import deepMerge from './deepMerge'
 
 export default function renderEslint(
   rootDir,
-  { needsTypeScript, needsCypress, needsCypressCT, needsPrettier }
+  { needsTypeScript, needsCypress, needsCypressCT, needsPrettier, needsEslintAirbnb }
 ) {
   const additionalConfig: Linter.Config = {}
   const additionalDependencies = {}
@@ -30,6 +30,10 @@ export default function renderEslint(
     ]
 
     additionalDependencies['eslint-plugin-cypress'] = eslintDeps['eslint-plugin-cypress']
+  }
+  if (needsEslintAirbnb) {
+    additionalConfig.extends = ['@vue/eslint-config-airbnb']
+    additionalDependencies['@vue/eslint-config-airbnb'] = eslintDeps['@vue/eslint-config-airbnb']
   }
 
   const { pkg, files } = createESLintConfig({


### PR DESCRIPTION
Many people like to use the @vue/eslint-config-airbnb rule
Allowed to be added when prompt is selected

![image](https://user-images.githubusercontent.com/61547749/211186496-bb0da877-2084-4da3-ab4d-b0b593a44318.png)
### .eslintrc.cjs
```javascript
/* eslint-env node */
module.exports = {
  root: true,
  'extends': [
    'plugin:vue/vue3-essential',
    'eslint:recommended',
    '@vue/eslint-config-airbnb' // Added when prompt option is selected
  ],
  parserOptions: {
    ecmaVersion: 'latest'
  }
}
```
### package.json
```javascript
  "devDependencies": {
    "@vitejs/plugin-vue": "^4.0.0",
    "@vue/eslint-config-airbnb": "^7.0.0", // Added when prompt option is selected
    "eslint": "^8.22.0",
    "eslint-plugin-vue": "^9.3.0",
    "vite": "^4.0.0"
  }
```