### PR TITLE
Add padding to a tag to make more visualised

### DIFF
--- a/template/base/src/assets/main.css
+++ b/template/base/src/assets/main.css
@@ -13,6 +13,8 @@ a,
   text-decoration: none;
   color: hsla(160, 100%, 37%, 1);
   transition: 0.4s;
+  padding: 3px;
+
 }
 
 @media (hover: hover) {


### PR DESCRIPTION
## Description
- Add padding to anchor tag to make more visible.


## Before: (Without padding)
<img width="561" alt="Screenshot 2023-02-01 at 12 46 39 PM" src="https://user-images.githubusercontent.com/35206101/215971894-341c1bf2-47d8-478b-8544-36aa8389329d.png">


## After: (With padding)
<img width="561" alt="Screenshot 2023-02-01 at 12 46 22 PM" src="https://user-images.githubusercontent.com/35206101/215973308-df307289-cdcf-4589-a0e0-f197713dac81.png">

