### PR TITLE
fix: change link to cypress api docs.

### DIFF
--- a/template/config/cypress/cypress/e2e/example.cy.js
+++ b/template/config/cypress/cypress/e2e/example.cy.js
@@ -1,4 +1,4 @@
-// https://docs.cypress.io/api/commands/and
+// https://on.cypress.io/api
 
 describe('My First Test', () => {
   it('visits the app root url', () => {

--- a/template/config/cypress/cypress/e2e/example.cy.js
+++ b/template/config/cypress/cypress/e2e/example.cy.js
@@ -1,4 +1,4 @@
-// https://docs.cypress.io/api/introduction/api.html
+// https://docs.cypress.io/api/commands/and
 
 describe('My First Test', () => {
   it('visits the app root url', () => {


### PR DESCRIPTION
The current link redirects to a 404 page.

![image](https://user-images.githubusercontent.com/38622893/222362402-7a40b9fc-f084-4cd6-ae39-8d7e0cbb8a55.png)

I've change the link to [The API Docs](https://docs.cypress.io/api/commands/and)
