### PR TITLE
fix: add `module: "ESNext"` to tsconfig.node

### DIFF
--- a/template/tsconfig/base/tsconfig.node.json
+++ b/template/tsconfig/base/tsconfig.node.json
@@ -3,6 +3,7 @@
   "include": ["vite.config.*", "vitest.config.*", "cypress.config.*", "playwright.config.*"],
   "compilerOptions": {
     "composite": true,
+    "module": "esnext",
     "types": ["node"]
   }
 }

--- a/template/tsconfig/base/tsconfig.node.json
+++ b/template/tsconfig/base/tsconfig.node.json
@@ -3,7 +3,7 @@
   "include": ["vite.config.*", "vitest.config.*", "cypress.config.*", "playwright.config.*"],
   "compilerOptions": {
     "composite": true,
-    "module": "esnext",
+    "module": "ESNext",
     "types": ["node"]
   }
 }


### PR DESCRIPTION
fix `vite.config.ts` error

```
The import.meta attribute is allowed only when the --module option is es2020, es2022, esnext, system, node16, or nodenext
```