### PR TITLE
fix: use `--build` for type-checking to be exaustive and less-fragile

### DIFF
--- a/template/base/_gitignore
+++ b/template/base/_gitignore
@@ -26,3 +26,5 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+
+*.tsbuildinfo

--- a/template/config/typescript/package.json
+++ b/template/config/typescript/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "build": "run-p type-check build-only",
     "build-only": "vite build",
-    "type-check": "vue-tsc --noEmit"
+    "type-check": "vue-tsc --build"
   },
   "devDependencies": {
     "@types/node": "^18.16.3",

--- a/template/tsconfig/base/tsconfig.app.json
+++ b/template/tsconfig/base/tsconfig.app.json
@@ -4,6 +4,7 @@
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,
+    "noEmit": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/template/tsconfig/base/tsconfig.node.json
+++ b/template/tsconfig/base/tsconfig.node.json
@@ -3,6 +3,7 @@
   "include": ["vite.config.*", "vitest.config.*", "cypress.config.*", "playwright.config.*"],
   "compilerOptions": {
     "composite": true,
+    "noEmit": true,
     "module": "ESNext",
     "types": ["node"]
   }

--- a/template/tsconfig/cypress-ct/package.json
+++ b/template/tsconfig/cypress-ct/package.json
@@ -1,5 +1,0 @@
-{
-  "scripts": {
-    "type-check": "vue-tsc --noEmit -p tsconfig.cypress-ct.json --composite false"
-  }
-}

--- a/template/tsconfig/vitest/package.json
+++ b/template/tsconfig/vitest/package.json
@@ -1,7 +1,4 @@
 {
-  "scripts": {
-    "type-check": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false"
-  },
   "devDependencies": {
     "@types/jsdom": "^21.1.1"
   }


### PR DESCRIPTION
Fixes #267

Thanks @segevfiner for noticing this new feature!

Currently there's still a small annoyance that `vue-tsc` would output an extra error message when there're type errors in `.vue` files https://github.com/vuejs/language-tools/issues/2622 But it works well if there's no error.

I've already submitted a PR to address it https://github.com/vuejs/language-tools/pull/3176