### PR TITLE
fix: specify the sub-project to type-check

### DIFF
--- a/template/config/typescript/package.json
+++ b/template/config/typescript/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "build": "run-p type-check build-only",
     "build-only": "vite build",
-    "type-check": "vue-tsc --noEmit"
+    "type-check": "vue-tsc --noEmit -p tsconfig.app.json --composite false"
   },
   "devDependencies": {
     "@types/node": "^18.16.3",


### PR DESCRIPTION
Fixes #267

It's because I moved the `compilerOptions` from `tsconfig.json` to `tsconfig.app.json` in the 2023-05-05 (v3.6.2) release, but forgot to change the `type-check` script.

This isn't comprehensive because it doesn't check all the sub-projects, but at least it's the same scope as previous versions.

Ideally I hope #274 can work reliably. But now I'm not sure. So let's first fix this bug.