### PR TITLE
fix: relative position in h1 and WelcomeItem

### DIFF
--- a/template/code/default/src/components/HelloWorld.vue
+++ b/template/code/default/src/components/HelloWorld.vue
@@ -22,6 +22,7 @@ defineProps({
 h1 {
   font-weight: 500;
   font-size: 2.6rem;
+  position: relative;
   top: -10px;
 }
 

--- a/template/code/router/src/components/HelloWorld.vue
+++ b/template/code/router/src/components/HelloWorld.vue
@@ -22,6 +22,7 @@ defineProps({
 h1 {
   font-weight: 500;
   font-size: 2.6rem;
+  position: relative;
   top: -10px;
 }
 

--- a/template/code/router/src/components/WelcomeItem.vue
+++ b/template/code/router/src/components/WelcomeItem.vue
@@ -16,6 +16,7 @@
 .item {
   margin-top: 2rem;
   display: flex;
+  position: relative;
 }
 
 .details {

--- a/template/code/typescript-default/src/components/HelloWorld.vue
+++ b/template/code/typescript-default/src/components/HelloWorld.vue
@@ -19,6 +19,7 @@ defineProps<{
 h1 {
   font-weight: 500;
   font-size: 2.6rem;
+  position: relative;
   top: -10px;
 }
 

--- a/template/code/typescript-default/src/components/WelcomeItem.vue
+++ b/template/code/typescript-default/src/components/WelcomeItem.vue
@@ -16,6 +16,7 @@
 .item {
   margin-top: 2rem;
   display: flex;
+  position: relative;
 }
 
 .details {

--- a/template/code/typescript-router/src/components/HelloWorld.vue
+++ b/template/code/typescript-router/src/components/HelloWorld.vue
@@ -19,6 +19,7 @@ defineProps<{
 h1 {
   font-weight: 500;
   font-size: 2.6rem;
+  position: relative;
   top: -10px;
 }
 

--- a/template/code/typescript-router/src/components/WelcomeItem.vue
+++ b/template/code/typescript-router/src/components/WelcomeItem.vue
@@ -16,6 +16,7 @@
 .item {
   margin-top: 2rem;
   display: flex;
+  position: relative;
 }
 
 .details {


### PR DESCRIPTION
Fix the incorrect position of `You did it!` heading and `WelcomeItem` introduced in #271

![Screenshot 2023-05-14 at 00.19.30.png](https://github.com/vuejs/create-vue/assets/29367025/ca1f0db1-e3b5-4e9f-92cc-550d838271f4)
![Screenshot 2023-05-14 at 00.20.45.png](https://github.com/vuejs/create-vue/assets/29367025/5e11f675-227e-400e-92da-5508a35b1a19)
