### PR TITLE
fix: `WelcomeItem` component style

### DIFF
--- a/template/code/router/src/components/WelcomeItem.vue
+++ b/template/code/router/src/components/WelcomeItem.vue
@@ -16,6 +16,7 @@
 .item {
   margin-top: 2rem;
   display: flex;
+  position: relative;
 }
 
 .details {

--- a/template/code/typescript-default/src/components/WelcomeItem.vue
+++ b/template/code/typescript-default/src/components/WelcomeItem.vue
@@ -16,6 +16,7 @@
 .item {
   margin-top: 2rem;
   display: flex;
+  position: relative;
 }
 
 .details {

--- a/template/code/typescript-router/src/components/WelcomeItem.vue
+++ b/template/code/typescript-router/src/components/WelcomeItem.vue
@@ -16,6 +16,7 @@
 .item {
   margin-top: 2rem;
   display: flex;
+  position: relative;
 }
 
 .details {


### PR DESCRIPTION
Due to the lack of the CSS property `position: relative` in these files, the initialization template icon cannot be displayed correctly.

![image](https://github.com/vuejs/create-vue/assets/38490578/44bfc615-37dc-43ae-8331-e9a73d184796)

