### PR TITLE
fix(config/typescript): pass build arguments to build-only command

### DIFF
--- a/template/config/typescript/package.json
+++ b/template/config/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "run-p type-check build-only",
+    "build": "run-p type-check \"build-only {@}\" --",
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit -p tsconfig.app.json --composite false"
   },


### PR DESCRIPTION
I was configuring builds with different modes and couldn't run ```yarn build --mode preview```  as I would do normally with simple ```vite build``` in my "build" script because of ```ERROR: Invalid Option: --mode```

Had to spend some time figuring this out, guess it may be a helpfull addition that will prevent someone from getting a similar issue