### PR TITLE
fix: Correct the 'build' command in the package.json file.

### DIFF
--- a/template/config/typescript/package.json
+++ b/template/config/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "run-p type-check \"build-only {@}\" --",
+    "build": "run-p type-check \"build-only -- {@}\" --",
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit -p tsconfig.app.json --composite false"
   },


### PR DESCRIPTION
The package.json file is located at template/config/typescript/package.json.

```run-p type-check \"build-only {@}\" --```  ->  ```run-p type-check \"build-only -- {@}\" --```

#393 