### PR TITLE
chore: explicitly set tsBuildInfoFile in tsconfig.*.json files

### DIFF
--- a/template/tsconfig/base/tsconfig.app.json
+++ b/template/tsconfig/base/tsconfig.app.json
@@ -4,7 +4,8 @@
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,
-    "noEmit": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/template/tsconfig/base/tsconfig.node.json
+++ b/template/tsconfig/base/tsconfig.node.json
@@ -10,6 +10,8 @@
   "compilerOptions": {
     "composite": true,
     "noEmit": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "types": ["node"]

--- a/template/tsconfig/cypress-ct/tsconfig.cypress-ct.json
+++ b/template/tsconfig/cypress-ct/tsconfig.cypress-ct.json
@@ -9,6 +9,7 @@
   ],
   "exclude": [],
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.cypress-ct.tsbuildinfo"
   }
 }

--- a/template/tsconfig/nightwatch-ct/tsconfig.app.json
+++ b/template/tsconfig/nightwatch-ct/tsconfig.app.json
@@ -4,7 +4,8 @@
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,
-    "noEmit": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/template/tsconfig/nightwatch/nightwatch/tsconfig.json
+++ b/template/tsconfig/nightwatch/nightwatch/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "noEmit": true,
-    "tsBuildInfoFile": "../node_modules/.tmp/nightwatch.tsbuildinfo",
+    "tsBuildInfoFile": "../node_modules/.tmp/tsconfig.nightwatch.tsbuildinfo",
 
     "target": "ESNext",
     "module": "commonjs",

--- a/template/tsconfig/nightwatch/nightwatch/tsconfig.json
+++ b/template/tsconfig/nightwatch/nightwatch/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "tsBuildInfoFile": "../node_modules/.tmp/nightwatch.tsbuildinfo",
+
     "target": "ESNext",
     "module": "commonjs",
     "moduleResolution": "node",
-    "composite": true,
-    "noEmit": true,
     "rootDir": "../",
     "lib": ["ESNext", "dom"],
     "types": ["nightwatch"]

--- a/template/tsconfig/vitest/tsconfig.vitest.json
+++ b/template/tsconfig/vitest/tsconfig.vitest.json
@@ -3,6 +3,8 @@
   "exclude": [],
   "compilerOptions": {
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
+
     "lib": [],
     "types": ["node", "jsdom"]
   }


### PR DESCRIPTION
To avoid polluting the root directory with tsconfig.*.tsbuildinfo files.

`outDir` in the base config doesn't work because of https://github.com/vuejs/tsconfig/issues/27#issuecomment-1859708129 Besides, we need this explicit config in `tsconfig.node.json` anyways, as it doesn't extend from `@vue/tsconfig`.

Using `.tmp` instead of `.cache` here to better indicate the purpose.