### PR TITLE
chore(deps): update script to enable cypress

### DIFF
--- a/template/config/cypress/package.json
+++ b/template/config/cypress/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
-    "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'"
+    "test:e2e:dev": "start-server-and-test 'vite dev --port 4173 --host' http://localhost:4173 'cypress open --e2e'"
   },
   "devDependencies": {
     "cypress": "^13.6.1",


### PR DESCRIPTION
Without `--port`, cypress can not visit the default URL. This is confusing.
![image](https://github.com/vuejs/create-vue/assets/85552719/ad9570c0-6106-48b0-bf1f-30bb37ff4c54)

