### PR TITLE
chore: simplify husky setup

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 pnpm exec lint-staged

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": ">=v16.20.0"
   },
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky",
     "format": "prettier --write .",
     "build": "zx ./scripts/build.mjs",
     "snapshot": "zx ./scripts/snapshot.mjs",
@@ -45,7 +45,7 @@
     "ejs": "^3.1.9",
     "esbuild": "^0.18.20",
     "esbuild-plugin-license": "^1.2.2",
-    "husky": "^9.0.1",
+    "husky": "^9.0.2",
     "kolorist": "^1.8.0",
     "lint-staged": "^15.2.0",
     "minimist": "^1.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2(esbuild@0.18.20)
       husky:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^9.0.2
+        version: 9.0.2
       kolorist:
         specifier: ^1.8.0
         version: 1.8.0
@@ -3705,8 +3705,8 @@ packages:
     engines: {node: '>=16.17.0'}
     dev: true
 
-  /husky@9.0.1:
-    resolution: {integrity: sha512-rXCT8yF2v3awSG03AG6IgICDhJ+m8o3jL1ROwsT4nQZ6urEyKSj0IWFDIh5YC2zgZeAxWksNMbN6rYY4BE1Zrw==}
+  /husky@9.0.2:
+    resolution: {integrity: sha512-0yR5R3OPjl8bYApi6T4QMOAwhtLhBjdYIVg5S6zSzIO8DIvQMh/b7Q8jW3WLbHLHtzpwiyMLBNB4R0Eb6x5+AA==}
     engines: {node: '>=18'}
     hasBin: true
     dev: true


### PR DESCRIPTION
husky v9 simplified its setup , see `How to migrate` in https://github.com/typicode/husky/releases/tag/v9.0.1