### PR TITLE
i18n: Update zh-Hans.json

### DIFF
--- a/locales/zh-Hans.json
+++ b/locales/zh-Hans.json
@@ -58,7 +58,7 @@
     "inactive": "否"
   },
   "infos": {
-    "scaffolding": "正在构建项目",
-    "done": "项目构建完成，可执行以下命令："
+    "scaffolding": "正在初始化项目",
+    "done": "项目初始化完成，可执行以下命令："
   }
 }


### PR DESCRIPTION
## Description

Update the i18n translation.

I think `构建` means `build`. `scaffolding` should be translated to `初始化`