### PR TITLE
feat: add vscode config for prettier

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -441,6 +441,9 @@ async function init() {
     })
   }
 
+  if (needsPrettier) {
+    render('config/prettier')
+  }
   // Render code template.
   // prettier-ignore
   const codeTemplate =

--- a/template/config/prettier/.vscode/extensions.json
+++ b/template/config/prettier/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/template/config/prettier/.vscode/settings.json
+++ b/template/config/prettier/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/utils/renderEslint.ts
+++ b/utils/renderEslint.ts
@@ -90,8 +90,5 @@ export default function renderEslint(
   const extensionsJsonPath = path.resolve(rootDir, '.vscode/extensions.json')
   const existingExtensions = JSON.parse(fs.readFileSync(extensionsJsonPath, 'utf8'))
   existingExtensions.recommendations.push('dbaeumer.vscode-eslint')
-  if (needsPrettier) {
-    existingExtensions.recommendations.push('esbenp.prettier-vscode')
-  }
   fs.writeFileSync(extensionsJsonPath, JSON.stringify(existingExtensions, null, 2) + '\n', 'utf-8')
 }


### PR DESCRIPTION
## Description

If the user pick prettier, then suggest the prettier .vscode extension, and add the settings.

#### settings.json
```
{
  "editor.defaultFormatter": "esbenp.prettier-vscode",
  "editor.formatOnSave": true
}
```

#### extensions.json
```
{
  "recommendations": ["esbenp.prettier-vscode"]
}
```

## Related Issue

re #302 

## Notes for Reviewers

1. Create **template/config/prettier/.vscode**:
   1.1. extensions.json
   1.2. settings.json
2. render('config/prettier') in **index.ts**
3. Remove logic from **renderEslint.ts** for esbenp.prettier-vscode, as it is now moved to a dedicated file (**template/config/prettier/.vscode/extensions.json**)

## Screenshots
### Generated project without prettier
<img width="220" alt="Screenshot 2024-02-05 at 20 52 54" src="https://github.com/vuejs/create-vue/assets/69005114/f5a32954-cff1-456a-8263-cf92470787ee">
<img width="733" alt="Screenshot 2024-02-05 at 20 55 51" src="https://github.com/vuejs/create-vue/assets/69005114/c06c89ad-5b86-49c0-a78b-44f2b1193984">


### Generated project with prettier
<img width="223" alt="Screenshot 2024-02-05 at 20 53 20" src="https://github.com/vuejs/create-vue/assets/69005114/8d1d8c7d-ef1c-46b3-90a9-56234ede07df">
<img width="535" alt="Screenshot 2024-02-05 at 20 54 48" src="https://github.com/vuejs/create-vue/assets/69005114/a7e603d9-516c-453e-a347-ef212d9f41e0">
<img width="409" alt="Screenshot 2024-02-05 at 20 54 41" src="https://github.com/vuejs/create-vue/assets/69005114/1ec42b4f-ce16-4462-9179-2cc626185ff4">



