### PR TITLE
feat: use `Intl.getCanonicalLocales` check locale

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -61,6 +61,9 @@ function emptyDir(dir) {
 }
 
 async function init() {
+  // The language information obtained may be incorrect. In this case, an error should be thrown and the banner information should not be printed.
+  const language = getLanguage()
+
   console.log()
   console.log(
     process.stdout.isTTY && process.stdout.getColorDepth() > 8
@@ -123,8 +126,6 @@ async function init() {
   const defaultProjectName = !targetDir ? 'vue-project' : targetDir
 
   const forceOverwrite = argv.force
-
-  const language = getLanguage()
 
   let result: {
     projectName?: string

--- a/index.ts
+++ b/index.ts
@@ -61,9 +61,6 @@ function emptyDir(dir) {
 }
 
 async function init() {
-  // The language information obtained may be incorrect. In this case, an error should be thrown and the banner information should not be printed.
-  const language = getLanguage()
-
   console.log()
   console.log(
     process.stdout.isTTY && process.stdout.getColorDepth() > 8
@@ -126,6 +123,8 @@ async function init() {
   const defaultProjectName = !targetDir ? 'vue-project' : targetDir
 
   const forceOverwrite = argv.force
+
+  const language = getLanguage()
 
   let result: {
     projectName?: string

--- a/utils/getLanguage.ts
+++ b/utils/getLanguage.ts
@@ -51,8 +51,13 @@ interface Language {
  * @returns locale that linked with correct name
  */
 function linkLocale(locale: string) {
-  // @ts-ignore
-  let linkedLocale: string = Intl.getCanonicalLocales(locale)[0]
+  let linkedLocale: string
+  try {
+    // @ts-ignore
+    linkedLocale = Intl.getCanonicalLocales(locale)[0]
+  } catch (error) {
+    console.log(`${error.toString()}\n`)
+  }
   switch (linkedLocale) {
     case 'zh-TW':
     case 'zh-HK':
@@ -63,6 +68,8 @@ function linkLocale(locale: string) {
     case 'zh-SG':
       linkedLocale = 'zh-Hans'
       break
+    default:
+      linkedLocale = locale
   }
 
   return linkedLocale

--- a/utils/getLanguage.ts
+++ b/utils/getLanguage.ts
@@ -51,8 +51,9 @@ interface Language {
  * @returns locale that linked with correct name
  */
 function linkLocale(locale: string) {
-  let linkedLocale: string
-  switch (locale) {
+  // @ts-ignore
+  let linkedLocale: string = Intl.getCanonicalLocales(locale)[0]
+  switch (linkedLocale) {
     case 'zh-TW':
     case 'zh-HK':
     case 'zh-MO':
@@ -62,8 +63,6 @@ function linkLocale(locale: string) {
     case 'zh-SG':
       linkedLocale = 'zh-Hans'
       break
-    default:
-      linkedLocale = locale
   }
 
   return linkedLocale


### PR DESCRIPTION
When users configure LANG related information by themselves, irregular spelling or capitalization problems may occur. However, I am not sure whether to throw an error directly to terminate the process at this time or just output the error message and continue to perform the following steps. (The current action I take is to print the error message and continue.)

Related commit https://github.com/vuejs/create-vue/commit/bb11f04a5319cecde4bd6e87c3bbb1612d7a88ae