### PR TITLE
refactor: delete Vue.vscode-typescript-vue-plugin

### DIFF
--- a/template/base/.vscode/extensions.json
+++ b/template/base/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar"]
 }

--- a/utils/generateReadme.ts
+++ b/utils/generateReadme.ts
@@ -4,7 +4,7 @@ const sfcTypeSupportDoc = [
   '',
   '## Type Support for `.vue` Imports in TS',
   '',
-  'TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin) to make the TypeScript language service aware of `.vue` types.',
+  'TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking.',
   '',
   "If the standalone TypeScript plugin doesn't feel fast enough to you, Volar has also implemented a [Take Over Mode](https://github.com/johnsoncodehk/volar/discussions/471#discussioncomment-1361669) that is more performant. You can enable it by the following steps:",
   '',
@@ -36,7 +36,7 @@ This template should help get you started developing with Vue 3 in Vite.
 
 ## Recommended IDE Setup
 
-[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur) + [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin).
+[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur).
 ${needsTypeScript ? sfcTypeSupportDoc : ''}
 ## Customize configuration
 

--- a/utils/generateReadme.ts
+++ b/utils/generateReadme.ts
@@ -5,13 +5,6 @@ const sfcTypeSupportDoc = [
   '## Type Support for `.vue` Imports in TS',
   '',
   'TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking.',
-  '',
-  "If the standalone TypeScript plugin doesn't feel fast enough to you, Volar has also implemented a [Take Over Mode](https://github.com/johnsoncodehk/volar/discussions/471#discussioncomment-1361669) that is more performant. You can enable it by the following steps:",
-  '',
-  '1. Disable the built-in TypeScript Extension',
-  "    1) Run `Extensions: Show Built-in Extensions` from VSCode's command palette",
-  '    2) Find `TypeScript and JavaScript Language Features`, right click and select `Disable (Workspace)`',
-  '2. Reload the VSCode window by running `Developer: Reload Window` from the command palette.',
   ''
 ].join('\n')
 

--- a/utils/generateReadme.ts
+++ b/utils/generateReadme.ts
@@ -4,7 +4,7 @@ const sfcTypeSupportDoc = [
   '',
   '## Type Support for `.vue` Imports in TS',
   '',
-  'TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking.',
+  'TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) to make the TypeScript language service aware of `.vue` types.',
   ''
 ].join('\n')
 


### PR DESCRIPTION
### Related Issue
re #455 

### Checklist
- [x] delete plugin from **template/base/.vscode/extensions.json**
- [x] delete plugin related information from **utils/generateReadme.ts**
- [x] delete "take over mode" information from  **utils/generateReadme.ts** (bacause takeover mode is depricated https://github.com/vuejs/language-tools/releases/tag/v2.0.0)