### PR TITLE
feat: add vscode config for ESLint

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -120,6 +120,7 @@ async function init() {
       argv.nightwatch ??
       argv.playwright ??
       argv.eslint ??
+      argv['eslint-with-prettier'] ??
       (argv.devtools || argv['vue-devtools'])
     ) === 'boolean'
 
@@ -463,6 +464,7 @@ async function init() {
       needsPrettier,
       needsPlaywright
     })
+    render('config/eslint')
   }
 
   if (needsPrettier) {

--- a/scripts/snapshot.mjs
+++ b/scripts/snapshot.mjs
@@ -15,12 +15,9 @@ const featureFlags = [
   'vitest',
   'cypress',
   'playwright',
-  'nightwatch',
-  'eslint',
-  'eslint-with-prettier'
+  'nightwatch'
 ]
 const featureFlagsDenylist = [
-  ['eslint', 'eslint-with-prettier'],
   ['cypress', 'playwright'],
   ['playwright', 'nightwatch'],
   ['cypress', 'nightwatch'],
@@ -57,7 +54,7 @@ function fullCombination(arr) {
 }
 
 let flagCombinations = fullCombination(featureFlags)
-flagCombinations.push(['default'], ['devtools'])
+flagCombinations.push(['default'], ['devtools'], ['eslint'], ['eslint-with-prettier'])
 
 // `--with-tests` are equivalent of `--vitest --cypress`
 // Previously it means `--cypress` without `--vitest`.

--- a/scripts/snapshot.mjs
+++ b/scripts/snapshot.mjs
@@ -15,9 +15,12 @@ const featureFlags = [
   'vitest',
   'cypress',
   'playwright',
-  'nightwatch'
+  'nightwatch',
+  'eslint',
+  'eslint-with-prettier'
 ]
 const featureFlagsDenylist = [
+  ['eslint', 'eslint-with-prettier'],
   ['cypress', 'playwright'],
   ['playwright', 'nightwatch'],
   ['cypress', 'nightwatch'],

--- a/template/config/eslint/.vscode/extensions.json
+++ b/template/config/eslint/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint"]
+}

--- a/template/config/eslint/.vscode/settings.json
+++ b/template/config/eslint/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  }
+}

--- a/utils/renderEslint.ts
+++ b/utils/renderEslint.ts
@@ -85,10 +85,4 @@ export default function renderEslint(
     const fullPath = path.resolve(rootDir, fileName)
     fs.writeFileSync(fullPath, content as string, 'utf-8')
   }
-
-  // update .vscode/extensions.json
-  const extensionsJsonPath = path.resolve(rootDir, '.vscode/extensions.json')
-  const existingExtensions = JSON.parse(fs.readFileSync(extensionsJsonPath, 'utf8'))
-  existingExtensions.recommendations.push('dbaeumer.vscode-eslint')
-  fs.writeFileSync(extensionsJsonPath, JSON.stringify(existingExtensions, null, 2) + '\n', 'utf-8')
 }

--- a/utils/renderTemplate.ts
+++ b/utils/renderTemplate.ts
@@ -51,6 +51,15 @@ function renderTemplate(src, dest, callbacks) {
     return
   }
 
+  if (filename === 'settings.json' && fs.existsSync(dest)) {
+    // merge instead of overwriting
+    const settings = JSON.parse(fs.readFileSync(dest, 'utf8'))
+    const newSettings = JSON.parse(fs.readFileSync(src, 'utf8'))
+    const extensions = deepMerge(settings, newSettings)
+    fs.writeFileSync(dest, JSON.stringify(settings, null, 2) + '\n')
+    return
+  }
+
   if (filename.startsWith('_')) {
     // rename `_file` to `.file`
     dest = path.resolve(path.dirname(dest), filename.replace(/^_/, '.'))


### PR DESCRIPTION
### Description
If the user picks ESLint, then suggest the ESLint .vscode extension, and add the settings.

**settings.json**
```
{
  "editor.codeActionsOnSave": {
    "source.fixAll": "explicit"
  }
}
```

**extensions.json**
```
{
  "recommendations": ["dbaeumer.vscode-eslint"]
}

```
### Related Issue
#466 

### Notes for Reviewers

-  **Created template/config/eslint** dedicated to ESLint's static settings, including .vscode/extensions.json and .vscode/settings.json.
- **Removed the existing code for adding the ESLint extension.**
- **Added code to merge Prettier settings into settings.json instead of overwriting them.**
- **Enabled generation of ESLint and Prettier snapshots.** 