### PR TITLE
feat: issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/1-feature_request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 ### Please describe
-Please provide us with a clear and concise description.
+<!-- Please provide us with a clear and concise description. -->
 
 ### Additional context
-Add any other context or screenshots about the feature request here. (If applicable)
+<!-- Add any other context or screenshots about the feature request here. (If applicable) -->

--- a/.github/ISSUE_TEMPLATE/1-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/1-feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+### Please describe
+Please provide us with a clear and concise description.
+
+### Additional context
+Add any other context or screenshots about the feature request here. (If applicable)

--- a/.github/ISSUE_TEMPLATE/2-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug_report.md
@@ -1,0 +1,30 @@
+---
+name: 🐞 Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+### Before You Start
+This form is only for submitting bug reports.
+
+### Describe the bug
+Please provide us with a clear and concise description of what the bug is.
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### How to reproduce
+It would be awesome if you could provide us a small reproduction online using stackblitz. You can replace `typescript-vitest` with another template name that is matching your case from https://github.com/vuejs/create-vue-templates.
+- https://stackblitz.com/github/vuejs/create-vue-templates/tree/main/typescript-vitest
+
+Steps to reproduce the behavior:
+1. Go to '....'
+2. Do this '....'
+3. Do that '....'
+4. Result
+
+### Screenshots
+Add screenshots to help explain your problem. (If applicable)

--- a/.github/ISSUE_TEMPLATE/2-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-<!-- This form is only for submitting bug reports. -->
+<!-- This form is only for submitting bug reports related to this repository (create-vue). -->
 
 ### Describe the bug
 <!-- Please provide us with a clear and concise description of what the bug is. -->

--- a/.github/ISSUE_TEMPLATE/2-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug_report.md
@@ -7,16 +7,16 @@ assignees: ''
 
 ---
 
-### Before You Start
-This form is only for submitting bug reports.
+<!-- This form is only for submitting bug reports. -->
 
 ### Describe the bug
-Please provide us with a clear and concise description of what the bug is.
+<!-- Please provide us with a clear and concise description of what the bug is. -->
 
 ### Expected behavior
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 ### How to reproduce
+<!----------------------------------------------------------------------
 It would be awesome if you could provide us a small reproduction online using stackblitz. You can replace `typescript-vitest` with another template name that is matching your case from https://github.com/vuejs/create-vue-templates.
 - https://stackblitz.com/github/vuejs/create-vue-templates/tree/main/typescript-vitest
 
@@ -24,7 +24,5 @@ Steps to reproduce the behavior:
 1. Go to '....'
 2. Do this '....'
 3. Do that '....'
-4. Result
-
-### Screenshots
-Add screenshots to help explain your problem. (If applicable)
+4. Result 
+----------------------------------------------------------------------->

--- a/.github/ISSUE_TEMPLATE/3-blank.md
+++ b/.github/ISSUE_TEMPLATE/3-blank.md
@@ -1,0 +1,8 @@
+---
+name: Blank issue
+about: Something other than a bug or a feature
+title: ''
+labels: ''
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# Reference: https://github.com/vuejs/core/blob/main/.github/ISSUE_TEMPLATE/config.yml
+contact_links:
+  - name: Discord Chat
+    url: https://chat.vuejs.org
+    about: Ask questions and discuss with other Vue users in real time.
+  - name: Questions & Discussions
+    url: https://github.com/vuejs/core/discussions
+    about: Use GitHub discussions for message-board style questions and discussions.
+  - name: Patreon
+    url: https://www.patreon.com/evanyou
+    about: Love Vue.js? Please consider supporting us via Patreon.
+  - name: Open Collective
+    url: https://opencollective.com/vuejs/donate
+    about: Love Vue.js? Please consider supporting us via Open Collective.


### PR DESCRIPTION
## Description

Overall structure is inspired by https://github.com/vuejs/core/issues/new/choose
Based on the number of issues in this repository, I don't think it's mandatory to hide blank issues.
`config.yml` is based on https://github.com/vuejs/core/blob/main/.github/ISSUE_TEMPLATE/config.yml The only difference is that **feature request link** is **removed** from there.

## Related Issue
re #474 

<img width="1107" alt="Screenshot 2024-03-30 at 1 39 48" src="https://github.com/vuejs/create-vue/assets/69005114/4293e2cc-d0d3-46c3-9072-e0ccf9384445">
