### PR TITLE
fix: exclude from vitest the playwright e2e/** subfolders

### DIFF
--- a/template/config/vitest/vitest.config.js
+++ b/template/config/vitest/vitest.config.js
@@ -7,7 +7,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       environment: 'jsdom',
-      exclude: [...configDefaults.exclude, 'e2e/*'],
+      exclude: [...configDefaults.exclude, 'e2e/**'],
       root: fileURLToPath(new URL('./', import.meta.url))
     }
   })


### PR DESCRIPTION
Fix : https://github.com/vuejs/create-vue/issues/486 