### PR TITLE
chore: use packageManager field to set pnpm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
-        with:
-          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -108,8 +106,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
-        with:
-          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.10.3",
   "description": "An easy way to start a Vue project",
   "type": "module",
+  "packageManager": "pnpm@8.15.1",
   "bin": {
     "create-vue": "outfile.cjs"
   },


### PR DESCRIPTION
### Description

The `pnpm/action-setup` on ci and the renovate bot will use this field to install the proper pnpm version