### PR TITLE
chore: drop last node v16 ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,16 +87,6 @@ jobs:
             flag-for-vitest: '--vitest'
             flag-for-e2e: '--cypress'
             flag-for-devtools: '--devtools'
-
-          - node-version: 16
-            os: ubuntu-latest
-            flag-for-ts: '--typescript'
-            flag-for-jsx: '--jsx'
-            flag-for-router: '--router'
-            flag-for-pinia: '--pinia'
-            flag-for-vitest: '--vitest'
-            flag-for-e2e: '--cypress'
-            flag-for-devtools: '--devtools'
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.os == 'windows-latest' }}
     env:


### PR DESCRIPTION
### Description

pnpm v9 won't run on node v16.
As node v16 is EOL, we can safely remove this job from ci.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->