### PR TITLE
chore: set `package-manager-strict` to false

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-manager-strict=false


### PR DESCRIPTION
### Description
After pnpm releases version [9.0.3](https://github.com/pnpm/pnpm/releases/tag/v9.0.3), when the local pnpm version and packageManger version do not match, an error message will appear and the process will exit when running `pnpm i`.
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->