### PR TITLE
fix: use lowercase for vueDevTools plugin

### DIFF
--- a/template/config/devtools/vite.config.js.data.mjs
+++ b/template/config/devtools/vite.config.js.data.mjs
@@ -1,8 +1,8 @@
 export default function getData({ oldData }) {
   const vueDevtoolsPlugin = {
     id: 'vite-plugin-vue-devtools',
-    importer: "import VueDevTools from 'vite-plugin-vue-devtools'",
-    initializer: 'VueDevTools()'
+    importer: "import vueDevTools from 'vite-plugin-vue-devtools'",
+    initializer: 'vueDevTools()'
   }
 
   return {


### PR DESCRIPTION
### Description

The other plugins (`vue`, `vueJsx` and `nightwatchPlugin`) all follow the same convention to have a lowercase at the start,
so let's do the same for `vueDevTools`