### PR TITLE
fix(cypress): remove es5 from tsconfig

### DIFF
--- a/template/tsconfig/cypress/cypress/e2e/tsconfig.json
+++ b/template/tsconfig/cypress/cypress/e2e/tsconfig.json
@@ -3,8 +3,6 @@
   "include": ["./**/*", "../support/**/*"],
   "compilerOptions": {
     "isolatedModules": false,
-    "target": "es5",
-    "lib": ["es5", "dom"],
     "types": ["cypress"]
   }
 }


### PR DESCRIPTION
### Description

It looks like this is no longer necessary and allows developers to use a more modern syntax in the spec files.