### PR TITLE
test: re-add eslint unit tests

### DIFF
--- a/__test__/renderEslint.spec.ts
+++ b/__test__/renderEslint.spec.ts
@@ -1,0 +1,101 @@
+import { it, describe, expect } from 'vitest'
+import { getAdditionalConfigs } from '../utils/renderEslint'
+
+describe('renderEslint', () => {
+  it('should get additional dependencies and config with no test flags', () => {
+    const additionalConfigs = getAdditionalConfigs({
+      needsVitest: false,
+      needsCypress: false,
+      needsCypressCT: false,
+      needsPlaywright: false
+    })
+    expect(additionalConfigs).toStrictEqual([])
+  })
+
+  it('should get additional dependencies and config with for vitest', () => {
+    const additionalConfigs = getAdditionalConfigs({
+      needsVitest: true,
+      needsCypress: false,
+      needsCypressCT: false,
+      needsPlaywright: false
+    })
+    expect(additionalConfigs).toHaveLength(1)
+    const [additionalVitestConfig] = additionalConfigs
+    expect(additionalVitestConfig.devDependencies['@vitest/eslint-plugin']).not.toBeUndefined()
+    expect(additionalVitestConfig.afterVuePlugin).toHaveLength(1)
+    const [additionalVitestPlugin] = additionalVitestConfig.afterVuePlugin!
+    expect(additionalVitestPlugin.importer).toBe(`import pluginVitest from '@vitest/eslint-plugin'`)
+    expect(additionalVitestPlugin.content).toContain('...pluginVitest.configs.recommended')
+    expect(additionalVitestPlugin.content).toContain("files: ['src/**/__tests__/*']")
+  })
+
+  it('should get additional dependencies and config with for cypress', () => {
+    const additionalConfigs = getAdditionalConfigs({
+      needsVitest: false,
+      needsCypress: true,
+      needsCypressCT: false,
+      needsPlaywright: false
+    })
+    expect(additionalConfigs).toHaveLength(1)
+    const [additionalCypressConfig] = additionalConfigs
+    expect(additionalCypressConfig.devDependencies['eslint-plugin-cypress']).not.toBeUndefined()
+    expect(additionalCypressConfig.afterVuePlugin).toHaveLength(1)
+    const [additionalCypressPlugin] = additionalCypressConfig.afterVuePlugin!
+    expect(additionalCypressPlugin.importer).toBe(
+      "import pluginCypress from 'eslint-plugin-cypress/flat'"
+    )
+    expect(additionalCypressPlugin.content).toContain('...pluginCypress.configs.recommended')
+    expect(additionalCypressPlugin.content).toContain(
+      "'cypress/e2e/**/*.{cy,spec}.{js,ts,jsx,tsx}'"
+    )
+    expect(additionalCypressPlugin.content).toContain("'cypress/support/**/*.{js,ts,jsx,tsx}'")
+  })
+
+  it('should get additional dependencies and config with for cypress with component testing', () => {
+    const additionalConfigs = getAdditionalConfigs({
+      needsVitest: false,
+      needsCypress: true,
+      needsCypressCT: true,
+      needsPlaywright: false
+    })
+    expect(additionalConfigs).toHaveLength(1)
+    const [additionalCypressConfig] = additionalConfigs
+    expect(additionalCypressConfig.devDependencies['eslint-plugin-cypress']).not.toBeUndefined()
+    expect(additionalCypressConfig.afterVuePlugin).toHaveLength(1)
+    const [additionalCypressPlugin] = additionalCypressConfig.afterVuePlugin!
+    expect(additionalCypressPlugin.importer).toBe(
+      "import pluginCypress from 'eslint-plugin-cypress/flat'"
+    )
+    expect(additionalCypressPlugin.content).toContain('...pluginCypress.configs.recommended')
+    expect(additionalCypressPlugin.content).toContain("'**/__tests__/*.{cy,spec}.{js,ts,jsx,tsx}'")
+    expect(additionalCypressPlugin.content).toContain(
+      "'cypress/e2e/**/*.{cy,spec}.{js,ts,jsx,tsx}'"
+    )
+    expect(additionalCypressPlugin.content).toContain("'cypress/support/**/*.{js,ts,jsx,tsx}'")
+  })
+
+  it('should get additional dependencies and config with for playwright', () => {
+    const additionalConfigs = getAdditionalConfigs({
+      needsVitest: false,
+      needsCypress: false,
+      needsCypressCT: false,
+      needsPlaywright: true
+    })
+    expect(additionalConfigs).toHaveLength(1)
+    const [additionalPlaywrightConfig] = additionalConfigs
+    expect(
+      additionalPlaywrightConfig.devDependencies['eslint-plugin-playwright']
+    ).not.toBeUndefined()
+    expect(additionalPlaywrightConfig.afterVuePlugin).toHaveLength(1)
+    const [additionalPlaywrightPlugin] = additionalPlaywrightConfig.afterVuePlugin!
+    expect(additionalPlaywrightPlugin.importer).toBe(
+      "import pluginPlaywright from 'eslint-plugin-playwright'"
+    )
+    expect(additionalPlaywrightPlugin.content).toContain(
+      "...pluginPlaywright.configs['flat/recommended']"
+    )
+    expect(additionalPlaywrightPlugin.content).toContain(
+      "files: ['e2e/**/*.{test,spec}.{js,ts,jsx,tsx}']"
+    )
+  })
+})

--- a/utils/renderEslint.ts
+++ b/utils/renderEslint.ts
@@ -83,7 +83,7 @@ export function getAdditionalConfigs({
           importer: `import pluginVitest from '@vitest/eslint-plugin'`,
           content: `
   {
-    ...pluginVitest.configs['recommended'],
+    ...pluginVitest.configs.recommended,
     files: ['src/**/__tests__/*'],
   },`
         }
@@ -107,7 +107,8 @@ export function getAdditionalConfigs({
         'cypress/support/**/*.{js,ts,jsx,tsx}'
       ]
         .map(JSON.stringify.bind(JSON))
-        .join(',\n      ')}
+        .join(',\n      ')
+        .replace(/"/g, "'")} // use single quotes as in the other configs
     ],
   },`
         }


### PR DESCRIPTION
### Description

Also fixes tiny discrepancies:
- all files are now declared with single quotes
- dot notation is preferred to access configs when possible

