### PR TITLE
feat: add vscode file nesting config to base template

### DIFF
--- a/template/base/.vscode/settings.json
+++ b/template/base/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "tsconfig.json": "tsconfig.*.json, env.d.ts",
+    "vite.config.*": "jsconfig*, vitest.config.*, cypress.config.*, playwright.config.*",
+    "package.json": "package-lock.json, pnpm*, .yarnrc*, yarn*, .eslint*, eslint*, .prettier*, prettier*, .editorconfig"
+  }
+}


### PR DESCRIPTION
We now have *a lot* of configuration files at the project's root. It would help to have them grouped in the editor.

Many people aren't aware of this feature, so I'm adding a default configuration to the base template to raise awareness.

This is a very rudimentary configuration; only patterns relevant to this project are included. Users can customize it further themselves.

Or they can use a more advanced share configuration like https://github.com/antfu/vscode-file-nesting-config

After applying the settings:
<img width="251" alt="image" src="https://github.com/user-attachments/assets/67eccb26-9c52-40ca-a1a9-4eb72fb392bf">

The expanded view:
<img width="261" alt="image" src="https://github.com/user-attachments/assets/148d4d7c-8d60-4832-975f-613bfca9a858">

