### PR TITLE
chore: delete kolorist as the project now uses kleur/colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "esbuild-plugin-license": "^1.2.3",
     "husky": "^9.1.6",
     "kleur": "^4.1.5",
-    "kolorist": "^1.8.0",
     "lint-staged": "^15.2.10",
     "prettier": "^3.3.3",
     "prompts": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
-      kolorist:
-        specifier: ^1.8.0
-        version: 1.8.0
       lint-staged:
         specifier: ^15.2.10
         version: 15.2.10
@@ -4828,14 +4825,6 @@ snapshots:
     optionalDependencies:
       vite: 5.4.8(@types/node@20.16.11)
 
-  '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(vite@5.4.8(@types/node@22.7.5))':
-    dependencies:
-      '@vitest/spy': 2.1.2
-      estree-walker: 3.0.3
-      magic-string: 0.30.11
-    optionalDependencies:
-      vite: 5.4.8(@types/node@22.7.5)
-
   '@vitest/pretty-format@2.1.2':
     dependencies:
       tinyrainbow: 1.2.0
@@ -7715,7 +7704,7 @@ snapshots:
   vitest@2.1.2(@types/node@22.7.5)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 2.1.2
-      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(vite@5.4.8(@types/node@22.7.5))
+      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(vite@5.4.8(@types/node@20.16.11))
       '@vitest/pretty-format': 2.1.2
       '@vitest/runner': 2.1.2
       '@vitest/snapshot': 2.1.2


### PR DESCRIPTION
### Description

Remove `kolorist` from package.json as the project now uses `kleur/colors`.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->
