### PR TITLE
feat: add EditorConfig to .vscode/extensions.json when ESLint is selected.

### DIFF
--- a/template/config/eslint/.vscode/extensions.json
+++ b/template/config/eslint/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint"]
+  "recommendations": ["dbaeumer.vscode-eslint", "EditorConfig.EditorConfig"]
 }


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR adds the EditorConfig.EditorConfig extension to the .vscode/extensions.json file when ESLint is selected during the create-vue project setup. This complements the [recent update](https://github.com/vuejs/create-eslint-config/commit/1d657db63bf500c0d8979cd5818d3dc1a9c23498) where .editorconfig is now added by default.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->
