### PR TITLE
fix(tempates): drop English as default language

### DIFF
--- a/template/base/index.html
+++ b/template/base/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="">
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">


### PR DESCRIPTION
Fixes #599; doesn't assume English as a page's default language in the base template.