### PR TITLE
feat: add experimental Oxlint integration

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -141,7 +141,8 @@ async function init() {
     needsPinia?: boolean
     needsVitest?: boolean
     needsE2eTesting?: false | 'cypress' | 'nightwatch' | 'playwright'
-    needsEslint?: boolean
+    needsEslint?: false | 'eslintOnly' | 'speedUpWithOxlint'
+    needsOxlint?: boolean
     needsPrettier?: boolean
     needsDevTools?: boolean
   } = {}
@@ -274,11 +275,24 @@ async function init() {
         },
         {
           name: 'needsEslint',
-          type: () => (isFeatureFlagsUsed ? null : 'toggle'),
+          type: () => (isFeatureFlagsUsed ? null : 'select'),
+          // FIXME:
           message: language.needsEslint.message,
-          initial: false,
-          active: language.defaultToggleOptions.active,
-          inactive: language.defaultToggleOptions.inactive,
+          initial: 0,
+          choices: [
+            {
+              title: language.needsEslint.selectOptions.negative.title,
+              value: false,
+            },
+            {
+              title: language.needsEslint.selectOptions.eslintOnly.title,
+              value: 'eslintOnly',
+            },
+            {
+              title: language.needsEslint.selectOptions.speedUpWithOxlint.title,
+              value: 'speedUpWithOxlint',
+            },
+          ],
         },
         {
           name: 'needsPrettier',
@@ -324,10 +338,12 @@ async function init() {
     needsRouter = argv.router || argv['vue-router'],
     needsPinia = argv.pinia,
     needsVitest = argv.vitest || argv.tests,
-    needsEslint = argv.eslint || argv['eslint-with-prettier'],
     needsPrettier = argv['eslint-with-prettier'],
     needsDevTools = argv.devtools || argv['vue-devtools'],
   } = result
+
+  const needsEslint = Boolean(argv.eslint || argv['eslint-with-prettier'] || result.needsEslint)
+  const needsOxlint = result.needsEslint === 'speedUpWithOxlint'
 
   const { needsE2eTesting } = result
   const needsCypress = argv.cypress || argv.tests || needsE2eTesting === 'cypress'
@@ -459,6 +475,7 @@ async function init() {
   if (needsEslint) {
     renderEslint(root, {
       needsTypeScript,
+      needsOxlint,
       needsVitest,
       needsCypress,
       needsCypressCT,

--- a/index.ts
+++ b/index.ts
@@ -276,7 +276,6 @@ async function init() {
         {
           name: 'needsEslint',
           type: () => (isFeatureFlagsUsed ? null : 'select'),
-          // FIXME:
           message: language.needsEslint.message,
           initial: 0,
           choices: [

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -45,7 +45,16 @@
     }
   },
   "needsEslint": {
-    "message": "Add ESLint for code quality?"
+    "message": "Add ESLint for code quality?",
+    "selectOptions": {
+      "negative": { "title": "No" },
+      "eslintOnly": {
+        "title": "Yes"
+      },
+      "speedUpWithOxlint": {
+        "title": "Yes, and speed up with Oxlint (experimental)"
+      }
+    }
   },
   "needsPrettier": {
     "message": "Add Prettier for code formatting?"

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -45,7 +45,16 @@
     }
   },
   "needsEslint": {
-    "message": "Ajouter ESLint pour la qualité du code\u00a0?"
+    "message": "Ajouter ESLint pour la qualité du code\u00a0?",
+    "selectOptions": {
+      "negative": { "title": "Non" },
+      "eslintOnly": {
+        "title": "Oui"
+      },
+      "speedUpWithOxlint": {
+        "title": "Oui, et accélérez avec Oxlint (expérimental)"
+      }
+    }
   },
   "needsPrettier": {
     "message": "Ajouter Prettier pour le formatage du code\u00a0?"

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -52,7 +52,7 @@
         "title": "Oui"
       },
       "speedUpWithOxlint": {
-        "title": "Oui, et accélérez avec Oxlint (expérimental)"
+        "title": "Oui, et accélérer avec Oxlint (expérimental)"
       }
     }
   },

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -45,7 +45,16 @@
     }
   },
   "needsEslint": {
-    "message": "Kod kalitesi için ESLint eklensin mi?"
+    "message": "Kod kalitesi için ESLint eklensin mi?",
+    "selectOptions": {
+      "negative": { "title": "Hayır" },
+      "eslintOnly": {
+        "title": "Evet"
+      },
+      "speedUpWithOxlint": {
+        "title": "Evet ve Oxlint ile hızlanın (deneysel)"
+      }
+    }
   },
   "needsPrettier": {
     "message": "Kod formatlama için Prettier eklensin mi?"

--- a/locales/zh-Hans.json
+++ b/locales/zh-Hans.json
@@ -45,7 +45,16 @@
     }
   },
   "needsEslint": {
-    "message": "是否引入 ESLint 用于代码质量检测？"
+    "message": "是否引入 ESLint 用于代码质量检测？",
+    "selectOptions": {
+      "negative": { "title": "否" },
+      "eslintOnly": {
+        "title": "是"
+      },
+      "speedUpWithOxlint": {
+        "title": "是，并同时引入 Oxlint 以加快检测（试验阶段）"
+      }
+    }
   },
   "needsPrettier": {
     "message": "是否引入 Prettier 用于代码格式化？"

--- a/locales/zh-Hant.json
+++ b/locales/zh-Hant.json
@@ -49,7 +49,16 @@
     }
   },
   "needsEslint": {
-    "message": "是否引入 ESLint 用於程式碼品質檢測？"
+    "message": "是否引入 ESLint 用於程式碼品質檢測？",
+    "selectOptions": {
+      "negative": { "title": "否" },
+      "eslintOnly": {
+        "title": "是"
+      },
+      "speedUpWithOxlint": {
+        "title": "是，並同時引入 Oxlint 以加快檢測（試驗性功能）"
+      }
+    }
   },
   "needsPrettier": {
     "message": "是否引入 Prettier 用於程式碼格式化？"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/eslint": "^9.6.1",
     "@types/node": "^20.17.6",
     "@types/prompts": "^2.4.9",
-    "@vue/create-eslint-config": "0.5.0",
+    "@vue/create-eslint-config": "^0.6.0",
     "@vue/tsconfig": "^0.5.1",
     "ejs": "^3.1.10",
     "esbuild": "^0.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^2.4.9
         version: 2.4.9
       '@vue/create-eslint-config':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@vue/tsconfig':
         specifier: ^0.5.1
         version: 0.5.1
@@ -1267,8 +1267,8 @@ packages:
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
 
-  '@vue/create-eslint-config@0.5.0':
-    resolution: {integrity: sha512-wXmFEDiuntXbNEtVtuBzhXXiIT5/M00gB9J3Io0tY9x4wznti64Xwj0//gA/f+cdp6kK8OmjYPeVTYZRLooimg==}
+  '@vue/create-eslint-config@0.6.0':
+    resolution: {integrity: sha512-IueSBgOXI+NzsG1ScPfGf1abU+cVNZ7i+nVLwTNanPkwt/Ocvj7qQWaDTLNb1TByRi1EIs9xJ81rbnDe8zY09g==}
     engines: {node: ^16.14.0 || >= 18.0.0}
     hasBin: true
 
@@ -4839,14 +4839,6 @@ snapshots:
     optionalDependencies:
       vite: 5.4.10(@types/node@20.17.6)
 
-  '@vitest/mocker@2.1.4(vite@5.4.10(@types/node@22.7.5))':
-    dependencies:
-      '@vitest/spy': 2.1.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.12
-    optionalDependencies:
-      vite: 5.4.10(@types/node@22.7.5)
-
   '@vitest/pretty-format@2.1.4':
     dependencies:
       tinyrainbow: 1.2.0
@@ -4979,7 +4971,7 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  '@vue/create-eslint-config@0.5.0':
+  '@vue/create-eslint-config@0.6.0':
     dependencies:
       ejs: 3.1.10
       enquirer: 2.4.1
@@ -7741,7 +7733,7 @@ snapshots:
   vitest@2.1.4(@types/node@22.7.5)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 2.1.4
-      '@vitest/mocker': 2.1.4(vite@5.4.10(@types/node@22.7.5))
+      '@vitest/mocker': 2.1.4(vite@5.4.10(@types/node@20.17.6))
       '@vitest/pretty-format': 2.1.4
       '@vitest/runner': 2.1.4
       '@vitest/snapshot': 2.1.4


### PR DESCRIPTION
Bumped `@vue/create-eslint-config` to 0.6.0 to support the new feature.

Note:
The `scripts` field generated in package.json for ESLint/Oxlint/Prettier
is now handled by `@vue/create-eslint-config` instead of here.

[Relevant commits](https://github.com/vuejs/create-eslint-config/compare/v0.5.0...v0.6.0#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346).

Hope I got the French & Turkish translations right.