### PR TITLE
perf: remove `--force` from the `type-check` script

### DIFF
--- a/template/config/typescript/package.json
+++ b/template/config/typescript/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "build": "run-p type-check \"build-only {@}\" --",
     "build-only": "vite build",
-    "type-check": "vue-tsc --build --force"
+    "type-check": "vue-tsc --build"
   },
   "devDependencies": {
     "@types/node": "^22.9.0",


### PR DESCRIPTION
It was introduced to work around a bug in `vue-tsc` that has been fixed in https://github.com/vuejs/language-tools/pull/3218 so no longer necessary.