### PR TITLE
refactor: remove `baseUrl` from all TSConfig files

### DIFF
--- a/template/tsconfig/base/tsconfig.app.json
+++ b/template/tsconfig/base/tsconfig.app.json
@@ -6,7 +6,6 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/template/tsconfig/nightwatch-ct/tsconfig.app.json
+++ b/template/tsconfig/nightwatch-ct/tsconfig.app.json
@@ -6,7 +6,6 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
Per the [official documentation](https://www.typescriptlang.org/tsconfig/#baseUrl):
> This feature was designed for use in conjunction with AMD module loaders in the browser, and is not recommended in any other context. As of TypeScript 4.1, baseUrl is no longer required to be set when using paths.

