### PR TITLE
Add run to build command when using bun

### DIFF
--- a/__test__/getCommand.spec.ts
+++ b/__test__/getCommand.spec.ts
@@ -17,4 +17,9 @@ describe('getCommand', () => {
     expect(getCommand('pnpm', 'dev')).toBe('pnpm dev')
     expect(getCommand('pnpm', 'build')).toBe('pnpm build')
   })
+  it('should generate the correct command for bun', () => {
+    expect(getCommand('bun', 'install')).toBe('bun install')
+    expect(getCommand('bun', 'dev')).toBe('bun dev')
+    expect(getCommand('bun', 'build')).toBe('bun run build')
+  })
 })

--- a/utils/getCommand.ts
+++ b/utils/getCommand.ts
@@ -2,6 +2,11 @@ export default function getCommand(packageManager: string, scriptName: string, a
   if (scriptName === 'install') {
     return packageManager === 'yarn' ? 'yarn' : `${packageManager} install`
   }
+  if (scriptName === 'build') {
+    return packageManager === 'npm' || packageManager === 'bun'
+      ? `${packageManager} run build`
+      : `${packageManager} build`
+  }
 
   if (args) {
     return packageManager === 'npm'


### PR DESCRIPTION
### Description

If the package manager is bun and the command is build generate 'bun run build' as the command to invoke the build script instead of the built-in 'bun build' command.

Resolves #614 

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->
