### PR TITLE
fix: remove `composite: true` from tsconfigs

### DIFF
--- a/template/tsconfig/base/tsconfig.app.json
+++ b/template/tsconfig/base/tsconfig.app.json
@@ -3,7 +3,6 @@
   "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
-    "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
     "paths": {

--- a/template/tsconfig/base/tsconfig.node.json
+++ b/template/tsconfig/base/tsconfig.node.json
@@ -8,7 +8,6 @@
     "playwright.config.*"
   ],
   "compilerOptions": {
-    "composite": true,
     "noEmit": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
 

--- a/template/tsconfig/cypress-ct/tsconfig.cypress-ct.json
+++ b/template/tsconfig/cypress-ct/tsconfig.cypress-ct.json
@@ -9,7 +9,6 @@
   ],
   "exclude": [],
   "compilerOptions": {
-    "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.cypress-ct.tsbuildinfo"
   }
 }

--- a/template/tsconfig/nightwatch-ct/tsconfig.app.json
+++ b/template/tsconfig/nightwatch-ct/tsconfig.app.json
@@ -3,7 +3,6 @@
   "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
-    "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
     "paths": {

--- a/template/tsconfig/nightwatch/nightwatch/tsconfig.json
+++ b/template/tsconfig/nightwatch/nightwatch/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "noEmit": true,
     "tsBuildInfoFile": "../node_modules/.tmp/tsconfig.nightwatch.tsbuildinfo",
 

--- a/template/tsconfig/vitest/tsconfig.vitest.json
+++ b/template/tsconfig/vitest/tsconfig.vitest.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.app.json",
+  "include": ["src/**/__tests__/*", "env.d.ts"],
   "exclude": [],
   "compilerOptions": {
-    "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
 
     "lib": [],


### PR DESCRIPTION
### Description

We are only using `references` in a solution-style tsconfig. According to discussions at https://github.com/microsoft/TypeScript/issues/60465, such usage doesn't require `composite: true` to be set in sub-configs.

Removing this field loosens the constraints on these configs that all checked files to be explicitly listed in `files` or `includes`.

After this change, type errors in source code would only be reported twice if they're also imported by unit test specs, in contrast to always be reported twice prior to the change.
I know this is not ideal yet, but it's still an improvement, and might help catch some edge cases such as https://github.com/vuejs/create-vue/issues/437#issuecomment-2468910155

In the long run, we should still keep an eye on https://github.com/vuejs/create-vue/pull/549 (pending https://github.com/vuejs/language-tools/issues/4750). Cross-referencing might be a more intuitive configuration, and should be the desirable configuration if we opt into Vitest Browser Mode.
