### PR TITLE
feat: use a `--bare` flag to generate a template without too much boilerplate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           verification-script:
             - pnpm --filter "\!*typescript*" build
             - pnpm --filter "*typescript*" build
-            - pnpm --filter "*vitest*" test:unit
+            - pnpm --filter "*vitest*" --filter "\!*bare*" test:unit
             - pnpm --filter "*eslint*" lint --no-fix --max-warnings=0
             - pnpm --filter "*prettier*" format --write --check
             # FIXME: it's failing now

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,13 @@ jobs:
           node-version: [18, 20, 22]
           os: [ubuntu-latest, windows-latest, macos-latest]
           verification-script:
-            - pnpm --filter "\!*typescript*" build
-            - pnpm --filter "*typescript*" build
-            - pnpm --filter "*vitest*" --filter "\!*bare*" test:unit
-            - pnpm --filter "*eslint*" lint --no-fix --max-warnings=0
-            - pnpm --filter "*prettier*" format --write --check
+            - pnpm --filter '!*typescript*' build
+            - pnpm --filter '*typescript*' build
+            - pnpm --filter '*vitest*' --filter '!*bare*' test:unit
+            - pnpm --filter '*eslint*' lint --no-fix --max-warnings=0
+            - pnpm --filter '*prettier*' format --write --check
             # FIXME: it's failing now
-            # - pnpm --filter "*with-tests*" test:unit
+            # - pnpm --filter '*with-tests*' test:unit
       runs-on: ${{ matrix.os }}
       continue-on-error: ${{ matrix.os == 'windows-latest' }}
       env:
@@ -163,11 +163,11 @@ jobs:
 
       - name: Run build script
         working-directory: ./playground
-        run: pnpm --filter "*${{ matrix.e2e-framework }}*" build
+        run: pnpm --filter '*${{ matrix.e2e-framework }}*' build
 
       - name: Run e2e test script
         working-directory: ./playground
-        run: pnpm --filter "*${{ matrix.e2e-framework }}*" --workspace-concurrency 1 test:e2e
+        run: pnpm --filter '*${{ matrix.e2e-framework }}*' --workspace-concurrency 1 test:e2e
 
       - name: Cypress component testing for projects without Vitest
         if: ${{ contains(matrix.e2e-framework, 'cypress') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,10 +167,10 @@ jobs:
 
       - name: Run e2e test script
         working-directory: ./playground
-        run: pnpm --filter '*${{ matrix.e2e-framework }}*' --workspace-concurrency 1 test:e2e
+        run: pnpm --filter '*${{ matrix.e2e-framework }}*' --filter '!*bare*' --workspace-concurrency 1 test:e2e
 
       - name: Cypress component testing for projects without Vitest
         if: ${{ contains(matrix.e2e-framework, 'cypress') }}
-        run: pnpm --filter '*cypress*' --filter '!*vitest*' --workspace-concurrency 1 test:unit
+        run: pnpm --filter '*cypress*' --filter '!*vitest*' --filter '!*bare*' --workspace-concurrency 1 test:unit
 
       # FIXME: `--with-tests` folders. It's failing now.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           verification-script:
             - pnpm --filter '!*typescript*' build
             - pnpm --filter '*typescript*' build
+            # bare templates only contain vitest configurations, but do not include unit test files
             - pnpm --filter '*vitest*' --filter '!*bare*' test:unit
             - pnpm --filter '*eslint*' lint --no-fix --max-warnings=0
             - pnpm --filter '*prettier*' format --write --check
@@ -167,10 +168,12 @@ jobs:
 
       - name: Run e2e test script
         working-directory: ./playground
+        # bare templates can't pass e2e tests because their page structures don't match the example tests
         run: pnpm --filter '*${{ matrix.e2e-framework }}*' --filter '!*bare*' --workspace-concurrency 1 test:e2e
 
       - name: Cypress component testing for projects without Vitest
         if: ${{ contains(matrix.e2e-framework, 'cypress') }}
+        # bare templates only contain test configurations, but do not include component test files
         run: pnpm --filter '*cypress*' --filter '!*vitest*' --filter '!*bare*' --workspace-concurrency 1 test:unit
 
       # FIXME: `--with-tests` folders. It's failing now.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,7 @@ jobs:
           verification-script:
             - pnpm --filter '!*typescript*' build
             - pnpm --filter '*typescript*' build
-            # bare templates only contain vitest configurations, but do not include unit test files
-            - pnpm --filter '*vitest*' --filter '!*bare*' test:unit
+            - pnpm --filter '*vitest*' test:unit
             - pnpm --filter '*eslint*' lint --no-fix --max-warnings=0
             - pnpm --filter '*prettier*' format --write --check
             # FIXME: it's failing now
@@ -173,7 +172,6 @@ jobs:
 
       - name: Cypress component testing for projects without Vitest
         if: ${{ contains(matrix.e2e-framework, 'cypress') }}
-        # bare templates only contain test configurations, but do not include component test files
-        run: pnpm --filter '*cypress*' --filter '!*vitest*' --filter '!*bare*' --workspace-concurrency 1 test:unit
+        run: pnpm --filter '*cypress*' --filter '!*vitest*' --workspace-concurrency 1 test:unit
 
       # FIXME: `--with-tests` folders. It's failing now.

--- a/index.ts
+++ b/index.ts
@@ -84,8 +84,9 @@ async function init() {
   // --playwright
   // --eslint
   // --eslint-with-prettier (only support prettier through eslint for simplicity)
-  // --force (for force overwriting)
-  // --bare (for a barebone template)
+  // in addition to the feature flags, you can also pass the following options:
+  // --bare (for a barebone template without example code)
+  // --force (for force overwriting without confirming)
 
   const args = process.argv.slice(2)
 

--- a/index.ts
+++ b/index.ts
@@ -568,6 +568,21 @@ async function init() {
 
   if (argv.bare) {
     trimBoilerplate(root, { needsTypeScript, needsRouter })
+    render('bare/base')
+
+    // TODO: refactor the `render` utility to avoid this kind of manual mapping?
+    if (needsTypeScript) {
+      render('bare/typescript')
+    }
+    if (needsVitest) {
+      render('bare/vitest')
+    }
+    if (needsCypressCT) {
+      render('bare/cypress-ct')
+    }
+    if (needsNightwatchCT) {
+      render('bare/nightwatch-ct')
+    }
   }
 
   // Instructions:

--- a/scripts/snapshot.mjs
+++ b/scripts/snapshot.mjs
@@ -55,6 +55,7 @@ function fullCombination(arr) {
 
 let flagCombinations = fullCombination(featureFlags)
 flagCombinations.push(
+  ['minimal'],
   ['default'],
   ['router', 'pinia'],
   ['eslint'],

--- a/scripts/snapshot.mjs
+++ b/scripts/snapshot.mjs
@@ -55,7 +55,6 @@ function fullCombination(arr) {
 
 let flagCombinations = fullCombination(featureFlags)
 flagCombinations.push(
-  ['minimal'],
   ['default'],
   ['router', 'pinia'],
   ['eslint'],

--- a/scripts/snapshot.mjs
+++ b/scripts/snapshot.mjs
@@ -8,6 +8,7 @@ if (!/pnpm/.test(process.env.npm_config_user_agent ?? ''))
   throw new Error("Please use pnpm ('pnpm run snapshot') to generate snapshots!")
 
 const featureFlags = [
+  'bare',
   'typescript',
   'jsx',
   'router',
@@ -54,11 +55,7 @@ function fullCombination(arr) {
 }
 
 let flagCombinations = fullCombination(featureFlags)
-flagCombinations.push(
-  ['default'],
-  ['eslint'],
-  ['eslint-with-prettier'],
-)
+flagCombinations.push(['default'], ['bare', 'default'], ['eslint'], ['eslint-with-prettier'])
 
 // `--with-tests` are equivalent of `--vitest --cypress`
 // Previously it means `--cypress` without `--vitest`.
@@ -84,10 +81,14 @@ for (const flags of flagCombinations) {
 }
 
 // Filter out combinations that are not allowed
-flagCombinations = flagCombinations.filter(
-  (combination) =>
-    !featureFlagsDenylist.some((denylist) => denylist.every((flag) => combination.includes(flag))),
-)
+flagCombinations = flagCombinations
+  .filter(
+    (combination) =>
+      !featureFlagsDenylist.some((denylist) =>
+        denylist.every((flag) => combination.includes(flag)),
+      ),
+  )
+  .filter((combination) => !(combination.length === 1 && combination[0] === 'bare'))
 
 const bin = path.posix.relative('../playground/', '../outfile.cjs')
 

--- a/scripts/snapshot.mjs
+++ b/scripts/snapshot.mjs
@@ -88,6 +88,7 @@ flagCombinations = flagCombinations
         denylist.every((flag) => combination.includes(flag)),
       ),
   )
+  // `--bare` is a supplementary flag and should not be used alone
   .filter((combination) => !(combination.length === 1 && combination[0] === 'bare'))
 
 const bin = path.posix.relative('../playground/', '../outfile.cjs')

--- a/scripts/snapshot.mjs
+++ b/scripts/snapshot.mjs
@@ -56,7 +56,6 @@ function fullCombination(arr) {
 let flagCombinations = fullCombination(featureFlags)
 flagCombinations.push(
   ['default'],
-  ['router', 'pinia'],
   ['eslint'],
   ['eslint-with-prettier'],
 )

--- a/template/bare/base/src/App.vue
+++ b/template/bare/base/src/App.vue
@@ -1,0 +1,7 @@
+<script setup></script>
+
+<template>
+  <h1>Hello World</h1>
+</template>
+
+<style scoped></style>

--- a/template/bare/cypress-ct/src/__tests__/App.cy.js
+++ b/template/bare/cypress-ct/src/__tests__/App.cy.js
@@ -1,0 +1,8 @@
+import App from '../App.vue'
+
+describe('App', () => {
+  it('mounts and renders properly', () => {
+    cy.mount(App)
+    cy.get('h1').should('contain', 'Hello World')
+  })
+})

--- a/template/bare/nightwatch-ct/src/__tests__/App.spec.js
+++ b/template/bare/nightwatch-ct/src/__tests__/App.spec.js
@@ -1,0 +1,14 @@
+describe('App', function () {
+  before((browser) => {
+    browser.init()
+  })
+
+  it('mounts and renders properly', async function () {
+    const appComponent = await browser.mountComponent('/src/App.vue');
+
+    browser.expect.element(appComponent).to.be.present;
+    browser.expect.element('h1').text.to.contain('Hello World');
+  })
+
+  after((browser) => browser.end())
+})

--- a/template/bare/typescript/src/App.vue
+++ b/template/bare/typescript/src/App.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts"></script>
+
+<template>
+  <h1>Hello World</h1>
+</template>
+
+<style scoped></style>

--- a/template/bare/vitest/src/__tests__/App.spec.js
+++ b/template/bare/vitest/src/__tests__/App.spec.js
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+
+import { mount } from '@vue/test-utils'
+import App from '../App.vue'
+
+describe('App', () => {
+  it('mounts renders properly', () => {
+    const wrapper = mount(App)
+    expect(wrapper.text()).toContain('Hello World')
+  })
+})

--- a/utils/trimBoilerplate.ts
+++ b/utils/trimBoilerplate.ts
@@ -26,7 +26,6 @@ export default function trimBoilerplate(rootDir: string, features: Record<string
   for (const filename of fs.readdirSync(srcDir)) {
     // Keep `App.vue`, `main.js/ts`, `router`, and `stores` directories
     if (['App.vue', 'main.js', 'main.ts', 'router', 'stores'].includes(filename)) {
-      console.log('continued')
       continue
     }
     const fullpath = path.resolve(srcDir, filename)

--- a/utils/trimBoilerplate.ts
+++ b/utils/trimBoilerplate.ts
@@ -1,0 +1,52 @@
+import * as fs from 'node:fs'
+import * as path from 'path'
+
+function getBareBoneAppContent(isTs: boolean) {
+  return `<script setup${isTs ? ' lang="ts"' : ''}>
+</script>
+
+<template>
+  <h1>Hello World</h1>
+</template>
+
+<style scoped>
+</style>
+`
+}
+
+function replaceContent(filepath: string, replacer: (content: string) => string) {
+  const content = fs.readFileSync(filepath, 'utf8')
+  fs.writeFileSync(filepath, replacer(content))
+}
+
+export default function trimBoilerplate(rootDir: string, features: Record<string, boolean>) {
+  const isTs = features.needsTypeScript
+  const srcDir = path.resolve(rootDir, 'src')
+
+  for (const filename of fs.readdirSync(srcDir)) {
+    // Keep `App.vue`, `main.js/ts`, `router`, and `stores` directories
+    if (['App.vue', 'main.js', 'main.ts', 'router', 'stores'].includes(filename)) {
+      console.log('continued')
+      continue
+    }
+    const fullpath = path.resolve(srcDir, filename)
+    fs.rmSync(fullpath, { recursive: true })
+  }
+
+  // Replace the content in `src/App.vue` with a barebone template
+  replaceContent(path.resolve(rootDir, 'src/App.vue'), () => getBareBoneAppContent(isTs))
+
+  // Remove CSS import in the entry file
+  const entryPath = path.resolve(rootDir, isTs ? 'src/main.ts' : 'src/main.js')
+  replaceContent(entryPath, (content) => content.replace("import './assets/main.css'\n\n", ''))
+
+  // If `router` feature is selected, use an empty router configuration
+  if (features.needsRouter) {
+    const routerEntry = path.resolve(srcDir, isTs ? 'router/index.ts' : 'router/index.js')
+    replaceContent(routerEntry, (content) =>
+      content
+        .replace(`import HomeView from '../views/HomeView.vue'\n`, '')
+        .replace(/routes:\s*\[[\s\S]*?\],/, 'routes: [],'),
+    )
+  }
+}

--- a/utils/trimBoilerplate.ts
+++ b/utils/trimBoilerplate.ts
@@ -1,19 +1,6 @@
 import * as fs from 'node:fs'
 import * as path from 'path'
 
-function getBareBoneAppContent(isTs: boolean) {
-  return `<script setup${isTs ? ' lang="ts"' : ''}>
-</script>
-
-<template>
-  <h1>Hello World</h1>
-</template>
-
-<style scoped>
-</style>
-`
-}
-
 function replaceContent(filepath: string, replacer: (content: string) => string) {
   const content = fs.readFileSync(filepath, 'utf8')
   fs.writeFileSync(filepath, replacer(content))
@@ -24,16 +11,14 @@ export default function trimBoilerplate(rootDir: string, features: Record<string
   const srcDir = path.resolve(rootDir, 'src')
 
   for (const filename of fs.readdirSync(srcDir)) {
-    // Keep `App.vue`, `main.js/ts`, `router`, and `stores` directories
-    if (['App.vue', 'main.js', 'main.ts', 'router', 'stores'].includes(filename)) {
+    // Keep `main.js/ts`, `router`, and `stores` directories
+    // `App.vue` would be re-rendered in the next step
+    if (['main.js', 'main.ts', 'router', 'stores'].includes(filename)) {
       continue
     }
     const fullpath = path.resolve(srcDir, filename)
     fs.rmSync(fullpath, { recursive: true })
   }
-
-  // Replace the content in `src/App.vue` with a barebone template
-  replaceContent(path.resolve(rootDir, 'src/App.vue'), () => getBareBoneAppContent(isTs))
 
   // Remove CSS import in the entry file
   const entryPath = path.resolve(rootDir, isTs ? 'src/main.ts' : 'src/main.js')


### PR DESCRIPTION
Closes #112
Closes #186
Closes #300
Closes #637

~~The minimal template is a cut-down version of the default template;
therefore, the `--minimal` flag is mutually exclusive with all other flags.~~

I chose not to include it in the prompts because it's a very specific
use case, and it's not a good idea to clutter the CLI with too many
options that are not commonly used.

~~I didn't design it as an add-on because the logic would be too complex,
and the use case would be even more niche.~~