### PR TITLE
ci: simplify CI matrix and more comprehensive tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,10 @@ jobs:
             key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
         - name: Build the package on cache miss
           if: steps.cache-restore.outputs.cache-hit != 'true'
-          run: pnpm install && pnpm build && pnpm snapshot && cd playground && pnpm install --no-frozen-lockfile
+          run: pnpm install && pnpm build && pnpm snapshot
+        - name: Install dependencies in playground
+          working-directory: ./playground
+          run: pnpm install --no-frozen-lockfile
 
         - name: Run build script in playground
           working-directory: ./playground
@@ -98,7 +101,10 @@ jobs:
           key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Build the package on cache miss
         if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: pnpm install && pnpm build && pnpm snapshot && cd playground && pnpm install --no-frozen-lockfile
+        run: pnpm install && pnpm build && pnpm snapshot
+      - name: Install dependencies in playground
+        working-directory: ./playground
+        run: pnpm install --no-frozen-lockfile
       - name: Run test:unit script in vitest projects
         working-directory: ./playground
         run: pnpm --filter "{*vitest*}" test:unit
@@ -137,7 +143,11 @@ jobs:
           key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Build the package on cache miss
         if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: pnpm install && pnpm build && pnpm snapshot && cd playground && pnpm install --no-frozen-lockfile
+        run: pnpm install && pnpm build && pnpm snapshot
+      - name: Install dependencies in playground
+        working-directory: ./playground
+        run: pnpm install --no-frozen-lockfile
+
       # https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml#L62
       # Install playwright's binary under custom directory to cache
       - name: Set Playwright & Cypress path

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,16 +58,12 @@ jobs:
         - uses: actions/cache/restore@v4
           id: cache-restore
           with:
-            path: |
-              outfile.cjs
-              playground
+            path: outfile.cjs
             key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
         - name: Build the package on cache miss
-          if: steps.cache-restore.outputs.cache-hit != 'true'
-          run: pnpm install && pnpm build && pnpm snapshot && echo "{}" > playground/package.json
-        - name: Move playground to an outside directory to work around working-directory issue
-          if: steps.cache-restore.outputs.cache-hit != 'true'
-          run: mv playground ../playground
+          run: pnpm install && pnpm build
+        - name: Snapshot
+          run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
         - name: Install dependencies in playground
           working-directory: ../playground
           run: pnpm install --no-frozen-lockfile
@@ -98,16 +94,13 @@ jobs:
       - uses: actions/cache/restore@v4
         id: cache-restore
         with:
-          path: |
-            outfile.cjs
-            ../playground
+          path: outfile.cjs
           key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Build the package on cache miss
         if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: pnpm install && pnpm build && pnpm snapshot && echo "{}" > playground/package.json
-      - name: Move playground to an outside directory to work around working-directory issue
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: mv playground ../playground
+        run: pnpm install && pnpm build
+      - name: Snapshot
+        run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
       - name: Install dependencies in playground
         working-directory: ../playground
         run: pnpm install --no-frozen-lockfile
@@ -143,16 +136,13 @@ jobs:
       - uses: actions/cache/restore@v4
         id: cache-restore
         with:
-          path: |
-            outfile.cjs
-            playground
+          path: outfile.cjs
           key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Build the package on cache miss
         if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: pnpm install && pnpm build && pnpm snapshot && echo "{}" > playground/package.json
-      - name: Move playground to an outside directory to work around working-directory issue
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: mv playground ../playground
+        run: pnpm install && pnpm build
+      - name: Snapshot
+        run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
       - name: Install dependencies in playground
         working-directory: ../playground
         run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        e2e-framework: ['cypress', 'playwright']
+        e2e-framework: ['cypress', 'playwright', 'nightwatch']
         node-version: [22]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -169,7 +169,7 @@ jobs:
         run: pnpm --filter "*${{ matrix.e2e-framework }}*" --workspace-concurrency 1 test:e2e
 
       - name: Cypress component testing for projects without Vitest
-        if: ${{ contains(matrix.e2e-framework, 'cypress') }}
+        if: ${{ contains(matrix.e2e-framework, 'cypress') || contains(matrix.e2e-framework, 'nightwatch') }}
         run: pnpm --filter '*cypress*' --filter '!*vitest*' --workspace-concurrency 1 test:unit
 
       # FIXME: `--with-tests` folders. It's failing now.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,10 @@ jobs:
         - name: Move playground to work around weird working-directory issue
           run: mv playground ../playground
         - name: Install dependencies in playground
-          working-directory: ../playground
-          run: pnpm recursive install --no-frozen-lockfile
+          run: pnpm -C ../playground install --no-frozen-lockfile
 
         - name: Run build script in playground
-          working-directory: ../playground
-          run: pnpm --filter "*" build
+          run: pnpm -C ../playground --filter "*" build
 
   # test-vitest:
   #   needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,15 @@ jobs:
               playground
             key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
         - name: Build the package on cache miss
-          run: pnpm install && pnpm build && pnpm snapshot && echo "{}" > playground/package.json
+          run: pnpm install && pnpm build && pnpm snapshot
+        - name: Move playground to work around weird working-directory issue
+          run: mv playground ../playground
         - name: Install dependencies in playground
-          working-directory: ./playground
+          working-directory: ../playground
           run: pnpm install --no-frozen-lockfile -r
 
         - name: Run build script in playground
-          working-directory: ./playground
+          working-directory: ../playground
           run: pnpm --filter "*" build
 
   # test-vitest:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,15 @@ jobs:
         - name: Build the package on cache miss
           if: steps.cache-restore.outputs.cache-hit != 'true'
           run: pnpm install && pnpm build && pnpm snapshot
+        - name: Move playground to an outside directory to work around working-directory issue
+          if: steps.cache-restore.outputs.cache-hit != 'true'
+          run: mv playground ../playground
         - name: Install dependencies in playground
-          working-directory: ./playground
+          working-directory: ../playground
           run: pnpm install --no-frozen-lockfile
 
         - name: Run build script in playground
-          working-directory: ./playground
+          working-directory: ../playground
           run: pnpm --filter "*" build
 
   test-vitest:
@@ -97,21 +100,24 @@ jobs:
         with:
           path: |
             outfile.cjs
-            playground
+            ../playground
           key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Build the package on cache miss
         if: steps.cache-restore.outputs.cache-hit != 'true'
         run: pnpm install && pnpm build && pnpm snapshot
+      - name: Move playground to an outside directory to work around working-directory issue
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: mv playground ../playground
       - name: Install dependencies in playground
-        working-directory: ./playground
+        working-directory: ../playground
         run: pnpm install --no-frozen-lockfile
       - name: Run test:unit script in vitest projects
-        working-directory: ./playground
+        working-directory: ../playground
         run: pnpm --filter "{*vitest*}" test:unit
 
       # FIXME: it's failing now
       # - name: Run test:unit script in with-tests projects
-      #   working-directory: ./playground
+      #   working-directory: ../playground
       #   run: pnpm --filter "{*with-tests*}" test:unit
 
   test-e2e:
@@ -144,8 +150,11 @@ jobs:
       - name: Build the package on cache miss
         if: steps.cache-restore.outputs.cache-hit != 'true'
         run: pnpm install && pnpm build && pnpm snapshot
+      - name: Move playground to an outside directory to work around working-directory issue
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: mv playground ../playground
       - name: Install dependencies in playground
-        working-directory: ./playground
+        working-directory: ../playground
         run: pnpm install --no-frozen-lockfile
 
       # https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml#L62
@@ -180,19 +189,19 @@ jobs:
 
       - name: Download Cypress
         if: ${{ contains(matrix.e2e-framework, 'cypress') }}
-        working-directory: ./playground
+        working-directory: ../playground
         run: |
           pnpm --filter "{cypress}" exec cypress cache list
           pnpm --filter "{cypress}" exec cypress install
 
       - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
         name: Install Playwright dependencies
-        working-directory: ./playground
+        working-directory: ../playground
         run: pnpm --filter "{playwright}" exec playwright install --with-deps
 
       # Run `test:e2e` in project folders contain `matrix.e2e-framework`
       - name: Run e2e test script
-        working-directory: ./playground
+        working-directory: ../playground
         run: pnpm --filter "{*${{ matrix.e2e-framework }}*}" test:e2e
 
       # FIXME: `--with-tests` folders

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,13 @@ jobs:
         working-directory: ./playground/playwright
         run: pnpm exec playwright install --with-deps
 
-      # Run `test:e2e` in project folders contain `matrix.e2e-framework`
+      - name: Run build script
+        working-directory: ./playground
+        run: pnpm --filter "*${{ matrix.e2e-framework }}*" build
+
       - name: Run e2e test script
         working-directory: ./playground
-        run: pnpm --filter "{*${{ matrix.e2e-framework }}*}" test:e2e
+        run: pnpm --filter "*${{ matrix.e2e-framework }}*" test:e2e
 
       # FIXME: `--with-tests` folders
       # FIXME: Cypress component testing for projects without Vitest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,15 +170,15 @@ jobs:
 
       - name: Download Cypress
         if: ${{ contains(matrix.e2e-framework, 'cypress') }}
-        working-directory: ./playground/cypress
+        working-directory: ./playground
         run: |
-          pnpm exec cypress cache list
-          pnpm exec cypress install
+          pnpm --filter "{cypress}" exec cypress cache list
+          pnpm --filter "{cypress}" exec cypress install
 
       - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
         name: Install Playwright dependencies
-        working-directory: ./playground/playwright
-        run: npx playwright install --with-deps
+        working-directory: ./playground
+        run: pnpm --filter "{playwright}" exec playwright install --with-deps
 
       # Run `test:e2e` in project folders contain `matrix.e2e-framework`
       - name: Run e2e test script

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,24 +99,23 @@ jobs:
       CYPRESS_VERIFY_TIMEOUT: 60000
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
+        with:
+          submodules: true
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
-      - uses: actions/cache/restore@v4
-        id: cache-restore
+      # use artifacts to share the playground across different jobs
+      - uses: actions/download-artifact@v4
         with:
-          path: outfile.cjs
-          key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Build the package on cache miss
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: pnpm install && pnpm build
-      - name: Snapshot
-        run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
+          name: build-output
+
+      - name: Install dependencies to avoid tsconfig warnings
+        run: pnpm install
       - name: Install dependencies in playground
-        working-directory: ../playground
+        working-directory: ./playground
         run: pnpm install --no-frozen-lockfile
 
       # https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml#L62
@@ -151,19 +150,19 @@ jobs:
 
       - name: Download Cypress
         if: ${{ contains(matrix.e2e-framework, 'cypress') }}
-        working-directory: ../playground
+        working-directory: ./playground/cypress
         run: |
-          pnpm --filter "{cypress}" exec cypress cache list
-          pnpm --filter "{cypress}" exec cypress install
+          pnpm exec cypress cache list
+          pnpm exec cypress install
 
       - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
         name: Install Playwright dependencies
-        working-directory: ../playground
-        run: pnpm --filter "{playwright}" exec playwright install --with-deps
+        working-directory: ./playground/playwright
+        run: pnpm exec playwright install --with-deps
 
       # Run `test:e2e` in project folders contain `matrix.e2e-framework`
       - name: Run e2e test script
-        working-directory: ../playground
+        working-directory: ./playground
         run: pnpm --filter "{*${{ matrix.e2e-framework }}*}" test:e2e
 
       # FIXME: `--with-tests` folders

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,15 @@ jobs:
       - run: pnpm build
       - run: pnpm test:unit
 
+      - run: pnpm snapshot
       # Use cache to share the output across different jobs
       # No need to cache node_modules because they are all bundled
       - uses: actions/cache/save@v4
         id: cache
         with:
-          path: outfile.cjs
+          path: |
+            outfile.cjs
+            playground
           key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
 
   test-build:
@@ -61,9 +64,9 @@ jobs:
             path: outfile.cjs
             key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
         - name: Build the package on cache miss
-          run: pnpm install && pnpm build
-        - name: Snapshot
-          run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
+          run: pnpm install && pnpm build && pnpm snapshot
+        - name: Move playground
+          run: echo "{}" > playground/package.json && mv playground ../playground
         - name: Install dependencies in playground
           working-directory: ../playground
           run: pnpm install --no-frozen-lockfile
@@ -72,131 +75,131 @@ jobs:
           working-directory: ../playground
           run: pnpm --filter "*" build
 
-  test-vitest:
-    needs: build
-    strategy:
-      matrix:
-        node-version: [22]
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
-    env:
-      CYPRESS_INSTALL_BINARY: 0
-      CHROMEDRIVER_SKIP_DOWNLOAD: true
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
+  # test-vitest:
+  #   needs: build
+  #   strategy:
+  #     matrix:
+  #       node-version: [22]
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   runs-on: ${{ matrix.os }}
+  #   continue-on-error: ${{ matrix.os == 'windows-latest' }}
+  #   env:
+  #     CYPRESS_INSTALL_BINARY: 0
+  #     CHROMEDRIVER_SKIP_DOWNLOAD: true
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: pnpm/action-setup@v3
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'pnpm'
 
-      - uses: actions/cache/restore@v4
-        id: cache-restore
-        with:
-          path: outfile.cjs
-          key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Build the package on cache miss
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: pnpm install && pnpm build
-      - name: Snapshot
-        run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
-      - name: Install dependencies in playground
-        working-directory: ../playground
-        run: pnpm install --no-frozen-lockfile
-      - name: Run test:unit script in vitest projects
-        working-directory: ../playground
-        run: pnpm --filter "{*vitest*}" test:unit
+  #     - uses: actions/cache/restore@v4
+  #       id: cache-restore
+  #       with:
+  #         path: outfile.cjs
+  #         key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
+  #     - name: Build the package on cache miss
+  #       if: steps.cache-restore.outputs.cache-hit != 'true'
+  #       run: pnpm install && pnpm build
+  #     - name: Snapshot
+  #       run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
+  #     - name: Install dependencies in playground
+  #       working-directory: ../playground
+  #       run: pnpm install --no-frozen-lockfile
+  #     - name: Run test:unit script in vitest projects
+  #       working-directory: ../playground
+  #       run: pnpm --filter "{*vitest*}" test:unit
 
-      # FIXME: it's failing now
-      # - name: Run test:unit script in with-tests projects
-      #   working-directory: ../playground
-      #   run: pnpm --filter "{*with-tests*}" test:unit
+  #     # FIXME: it's failing now
+  #     # - name: Run test:unit script in with-tests projects
+  #     #   working-directory: ../playground
+  #     #   run: pnpm --filter "{*with-tests*}" test:unit
 
-  test-e2e:
-    needs: build
-    strategy:
-      matrix:
-        e2e-framework: ['cypress', 'playwright']
-        node-version: [22]
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
-    env:
-      # Sometimes the Linux runner can't verify Cypress in 30s
-      CYPRESS_VERIFY_TIMEOUT: 60000
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
+  # test-e2e:
+  #   needs: build
+  #   strategy:
+  #     matrix:
+  #       e2e-framework: ['cypress', 'playwright']
+  #       node-version: [22]
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   runs-on: ${{ matrix.os }}
+  #   continue-on-error: ${{ matrix.os == 'windows-latest' }}
+  #   env:
+  #     # Sometimes the Linux runner can't verify Cypress in 30s
+  #     CYPRESS_VERIFY_TIMEOUT: 60000
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: pnpm/action-setup@v3
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'pnpm'
 
-      - uses: actions/cache/restore@v4
-        id: cache-restore
-        with:
-          path: outfile.cjs
-          key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Build the package on cache miss
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: pnpm install && pnpm build
-      - name: Snapshot
-        run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
-      - name: Install dependencies in playground
-        working-directory: ../playground
-        run: pnpm install --no-frozen-lockfile
+  #     - uses: actions/cache/restore@v4
+  #       id: cache-restore
+  #       with:
+  #         path: outfile.cjs
+  #         key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
+  #     - name: Build the package on cache miss
+  #       if: steps.cache-restore.outputs.cache-hit != 'true'
+  #       run: pnpm install && pnpm build
+  #     - name: Snapshot
+  #       run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
+  #     - name: Install dependencies in playground
+  #       working-directory: ../playground
+  #       run: pnpm install --no-frozen-lockfile
 
-      # https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml#L62
-      # Install playwright's binary under custom directory to cache
-      - name: Set Playwright & Cypress path
-        run: |
-          echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $GITHUB_ENV
-          echo "CYPRESS_CACHE_FOLDER=$HOME/.cache/cypress-bin" >> $GITHUB_ENV
-      - name: Set Playwright & Cypress path (windows)
-        if: runner.os == 'Windows'
-        run: |
-          echo "PLAYWRIGHT_BROWSERS_PATH=$HOME\.cache\playwright-bin" >> $env:GITHUB_ENV
-          echo "CYPRESS_CACHE_FOLDER=$HOME\.cache\cypress-bin" >> $env:GITHUB_ENV
+  #     # https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml#L62
+  #     # Install playwright's binary under custom directory to cache
+  #     - name: Set Playwright & Cypress path
+  #       run: |
+  #         echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $GITHUB_ENV
+  #         echo "CYPRESS_CACHE_FOLDER=$HOME/.cache/cypress-bin" >> $GITHUB_ENV
+  #     - name: Set Playwright & Cypress path (windows)
+  #       if: runner.os == 'Windows'
+  #       run: |
+  #         echo "PLAYWRIGHT_BROWSERS_PATH=$HOME\.cache\playwright-bin" >> $env:GITHUB_ENV
+  #         echo "CYPRESS_CACHE_FOLDER=$HOME\.cache\cypress-bin" >> $env:GITHUB_ENV
 
-      - if: ${{ contains(matrix.e2e-framework, 'cypress') }}
-        name: Cache Cypress binaries
-        id: cache-cypress
-        uses: actions/cache@v4
-        with:
-          # TODO: avoid snowballing by adding version
-          key: ${{ runner.os }}-cypress-bin
-          path: ${{ env.CYPRESS_CACHE_FOLDER }}
+  #     - if: ${{ contains(matrix.e2e-framework, 'cypress') }}
+  #       name: Cache Cypress binaries
+  #       id: cache-cypress
+  #       uses: actions/cache@v4
+  #       with:
+  #         # TODO: avoid snowballing by adding version
+  #         key: ${{ runner.os }}-cypress-bin
+  #         path: ${{ env.CYPRESS_CACHE_FOLDER }}
 
-      - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
-        name: Cache Playwright's binary
-        uses: actions/cache@v4
-        with:
-          # Playwright removes unused browsers automatically
-          # So does not need to add playwright version to key
-          key: ${{ runner.os }}-playwright-bin-v1
-          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+  #     - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
+  #       name: Cache Playwright's binary
+  #       uses: actions/cache@v4
+  #       with:
+  #         # Playwright removes unused browsers automatically
+  #         # So does not need to add playwright version to key
+  #         key: ${{ runner.os }}-playwright-bin-v1
+  #         path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
 
-      - name: Download Cypress
-        if: ${{ contains(matrix.e2e-framework, 'cypress') }}
-        working-directory: ../playground
-        run: |
-          pnpm --filter "{cypress}" exec cypress cache list
-          pnpm --filter "{cypress}" exec cypress install
+  #     - name: Download Cypress
+  #       if: ${{ contains(matrix.e2e-framework, 'cypress') }}
+  #       working-directory: ../playground
+  #       run: |
+  #         pnpm --filter "{cypress}" exec cypress cache list
+  #         pnpm --filter "{cypress}" exec cypress install
 
-      - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
-        name: Install Playwright dependencies
-        working-directory: ../playground
-        run: pnpm --filter "{playwright}" exec playwright install --with-deps
+  #     - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
+  #       name: Install Playwright dependencies
+  #       working-directory: ../playground
+  #       run: pnpm --filter "{playwright}" exec playwright install --with-deps
 
-      # Run `test:e2e` in project folders contain `matrix.e2e-framework`
-      - name: Run e2e test script
-        working-directory: ../playground
-        run: pnpm --filter "{*${{ matrix.e2e-framework }}*}" test:e2e
+  #     # Run `test:e2e` in project folders contain `matrix.e2e-framework`
+  #     - name: Run e2e test script
+  #       working-directory: ../playground
+  #       run: pnpm --filter "{*${{ matrix.e2e-framework }}*}" test:e2e
 
-      # FIXME: `--with-tests` folders
-      # FIXME: Cypress component testing for projects without Vitest
+  #     # FIXME: `--with-tests` folders
+  #     # FIXME: Cypress component testing for projects without Vitest
 
 
-  # FIXME: test-lint
-  # `pnpm lint --no-fix --max-warnings=0`
+  # # FIXME: test-lint
+  # # `pnpm lint --no-fix --max-warnings=0`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
       runs-on: ${{ matrix.os }}
       continue-on-error: ${{ matrix.os == 'windows-latest' }}
       env:
-        # Sometimes the Linux runner can't verify Cypress in 30s
-        CYPRESS_VERIFY_TIMEOUT: 60000
+        CYPRESS_INSTALL_BINARY: 0
+        CHROMEDRIVER_SKIP_DOWNLOAD: true
       steps:
         - uses: actions/checkout@v4
         - uses: pnpm/action-setup@v3
@@ -66,15 +66,13 @@ jobs:
               playground
             key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
         - name: Build the package on cache miss
-          run: pnpm install && pnpm build && pnpm snapshot
-        - name: Move playground
-          run: echo "{}" > playground/package.json && mv playground ../playground
+          run: pnpm install && pnpm build && pnpm snapshot && echo "{}" > playground/package.json
         - name: Install dependencies in playground
-          working-directory: ../playground
+          working-directory: ./playground
           run: pnpm install --no-frozen-lockfile -r
 
         - name: Run build script in playground
-          working-directory: ../playground
+          working-directory: ./playground
           run: pnpm --filter "*" build
 
   # test-vitest:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,10 @@ jobs:
             - pnpm --filter "\!*typescript*" build
             - pnpm --filter "*typescript*" build
             - pnpm --filter "*vitest*" test:unit
+            - pnpm --filter "*eslint*" lint --no-fix --max-warnings=0
+            - pnpm --filter "*prettier*" format --write --check
             # FIXME: it's failing now
             # - pnpm --filter "*with-tests*" test:unit
-            # TODO: lint
       runs-on: ${{ matrix.os }}
       continue-on-error: ${{ matrix.os == 'windows-latest' }}
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,36 +11,36 @@ on:
     branches:
       - '**'
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    name: Build the package
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-      - run: pnpm install
-        env:
-          CYPRESS_INSTALL_BINARY: 0
-          CHROMEDRIVER_SKIP_DOWNLOAD: true
-      - run: pnpm build
-      - run: pnpm test:unit
+  # build:
+  #   runs-on: ubuntu-latest
+  #   name: Build the package
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: pnpm/action-setup@v3
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 22
+  #         cache: 'pnpm'
+  #     - run: pnpm install
+  #       env:
+  #         CYPRESS_INSTALL_BINARY: 0
+  #         CHROMEDRIVER_SKIP_DOWNLOAD: true
+  #     - run: pnpm build
+  #     - run: pnpm test:unit
 
-      - run: pnpm snapshot
-      # Use cache to share the output across different jobs
-      # No need to cache node_modules because they are all bundled
-      - uses: actions/cache/save@v4
-        id: cache
-        with:
-          path: |
-            outfile.cjs
-            playground
-          key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
+  #     - run: pnpm snapshot
+  #     # Use cache to share the output across different jobs
+  #     # No need to cache node_modules because they are all bundled
+  #     - uses: actions/cache/save@v4
+  #       id: cache
+  #       with:
+  #         path: |
+  #           outfile.cjs
+  #           playground
+  #         key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
 
   test-build:
-      needs: build
+      # needs: build
       strategy:
         matrix:
           node-version: [22]
@@ -58,14 +58,14 @@ jobs:
             node-version: ${{ matrix.node-version }}
             cache: 'pnpm'
 
-        - uses: actions/cache/restore@v4
-          id: cache-restore
-          with:
-            path: |
-              outfile.cjs
-              playground
-            key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
-        - name: Build the package on cache miss
+        # - uses: actions/cache/restore@v4
+        #   id: cache-restore
+        #   with:
+        #     path: |
+        #       outfile.cjs
+        #       playground
+        #     key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
+        - name: Build the package
           run: pnpm install && pnpm build && pnpm snapshot
         - run: echo "{}" > playground/package.json
         - name: Install dependencies in playground

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,14 +170,14 @@ jobs:
 
       - name: Download Cypress
         if: ${{ contains(matrix.e2e-framework, 'cypress') }}
-        working-directory: ./playground
+        working-directory: ./playground/cypress
         run: |
           pnpm exec cypress cache list
           pnpm exec cypress install
 
       - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
         name: Install Playwright dependencies
-        working-directory: ./playground
+        working-directory: ./playground/playwright
         run: npx playwright install --with-deps
 
       # Run `test:e2e` in project folders contain `matrix.e2e-framework`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - run: pnpm install
         env:
           CYPRESS_INSTALL_BINARY: 0
+          CHROMEDRIVER_SKIP_DOWNLOAD: true
       - run: pnpm build
       - run: pnpm test:unit
 
@@ -35,72 +36,88 @@ jobs:
           path: outfile.cjs
           key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
 
-  test:
+  test-build:
+      needs: build
+      strategy:
+        matrix:
+          node-version: [22]
+          os: [ubuntu-latest, windows-latest, macos-latest]
+      runs-on: ${{ matrix.os }}
+      continue-on-error: ${{ matrix.os == 'windows-latest' }}
+      env:
+        # Sometimes the Linux runner can't verify Cypress in 30s
+        CYPRESS_VERIFY_TIMEOUT: 60000
+      steps:
+        - uses: actions/checkout@v4
+        - uses: pnpm/action-setup@v3
+        - uses: actions/setup-node@v4
+          with:
+            node-version: ${{ matrix.node-version }}
+            cache: 'pnpm'
+
+        - uses: actions/cache/restore@v4
+          id: cache-restore
+          with:
+            path: |
+              outfile.cjs
+              playground
+            key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
+        - name: Build the package on cache miss
+          if: steps.cache-restore.outputs.cache-hit != 'true'
+          run: pnpm install && pnpm build && pnpm snapshot && cd playground && pnpm install --no-frozen-lockfile
+
+        - name: Run build script in playground
+          working-directory: ./playground
+          run: pnpm --filter "*" build
+
+  test-vitest:
     needs: build
     strategy:
       matrix:
-        flag-for-ts: ['', '--typescript']
-        flag-for-jsx: ['', '--jsx']
-        flag-for-router: ['', '--router']
-        flag-for-pinia: ['', '--pinia']
-        flag-for-vitest: ['', '--vitest']
-
-        # It's quite costly to install Cypress & Playwright even with cache.
-        # Maybe we can split them into another job so that all the projects
-        # can share the same binary installation.
-        flag-for-e2e: ['', '--cypress', '--playwright']
-
-        # Skip ESLint/Prettier tests as we've reached the limit of job numbers
-        # TODO: Find a way to test them without adding new jobs
-
         node-version: [22]
-        os: [ubuntu-latest]
-
-        # Run a few tests on other systems and Node.js versions
-        include:
-          - node-version: 22
-            os: windows-latest
-            flag-for-ts: '--typescript'
-            flag-for-jsx: '--jsx'
-            flag-for-router: '--router'
-            flag-for-pinia: '--pinia'
-            flag-for-vitest: '--vitest'
-            flag-for-e2e: '--cypress'
-            flag-for-eslint: '--eslint'
-
-          - node-version: 22
-            os: macos-latest
-            flag-for-ts: '--typescript'
-            flag-for-jsx: '--jsx'
-            flag-for-router: '--router'
-            flag-for-pinia: '--pinia'
-            flag-for-vitest: '--vitest'
-            flag-for-e2e: '--cypress'
-            flag-for-eslint: '--eslint'
-
-          - node-version: 18
-            os: ubuntu-latest
-            flag-for-ts: '--typescript'
-            flag-for-jsx: '--jsx'
-            flag-for-router: '--router'
-            flag-for-pinia: '--pinia'
-            flag-for-vitest: '--vitest'
-            flag-for-e2e: '--cypress'
-            flag-for-eslint: '--eslint'
-
-          - node-version: 20
-            os: ubuntu-latest
-            flag-for-ts: '--typescript'
-            flag-for-jsx: '--jsx'
-            flag-for-router: '--router'
-            flag-for-pinia: '--pinia'
-            flag-for-vitest: '--vitest'
-            flag-for-e2e: '--cypress'
-            flag-for-eslint: '--eslint'
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.os == 'windows-latest' }}
     env:
-      FEATURE_FLAGS: ${{ matrix.flag-for-ts }} ${{ matrix.flag-for-jsx }} ${{ matrix.flag-for-router }} ${{ matrix.flag-for-pinia }} ${{ matrix.flag-for-vitest }} ${{ matrix.flag-for-e2e }} ${{matrix.flag-for-eslint}}
+      CYPRESS_INSTALL_BINARY: 0
+      CHROMEDRIVER_SKIP_DOWNLOAD: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - uses: actions/cache/restore@v4
+        id: cache-restore
+        with:
+          path: |
+            outfile.cjs
+            playground
+          key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Build the package on cache miss
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: pnpm install && pnpm build && pnpm snapshot && cd playground && pnpm install --no-frozen-lockfile
+      - name: Run test:unit script in vitest projects
+        working-directory: ./playground
+        run: pnpm --filter "{*vitest*}" test:unit
+
+      # FIXME: it's failing now
+      # - name: Run test:unit script in with-tests projects
+      #   working-directory: ./playground
+      #   run: pnpm --filter "{*with-tests*}" test:unit
+
+  test-e2e:
+    needs: build
+    strategy:
+      matrix:
+        e2e-framework: ['cypress', 'playwright']
+        node-version: [22]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    env:
       # Sometimes the Linux runner can't verify Cypress in 30s
       CYPRESS_VERIFY_TIMEOUT: 60000
     steps:
@@ -110,19 +127,20 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
+
       - uses: actions/cache/restore@v4
         id: cache-restore
         with:
-          path: outfile.cjs
+          path: |
+            outfile.cjs
+            playground
           key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Build the package on cache miss
         if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: pnpm install && pnpm build
-
+        run: pnpm install && pnpm build && pnpm snapshot && cd playground && pnpm install --no-frozen-lockfile
       # https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml#L62
       # Install playwright's binary under custom directory to cache
       - name: Set Playwright & Cypress path
-        if: runner.os != 'Windows'
         run: |
           echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $GITHUB_ENV
           echo "CYPRESS_CACHE_FOLDER=$HOME/.cache/cypress-bin" >> $GITHUB_ENV
@@ -132,7 +150,7 @@ jobs:
           echo "PLAYWRIGHT_BROWSERS_PATH=$HOME\.cache\playwright-bin" >> $env:GITHUB_ENV
           echo "CYPRESS_CACHE_FOLDER=$HOME\.cache\cypress-bin" >> $env:GITHUB_ENV
 
-      - if: ${{ contains(matrix.flag-for-e2e, '--cypress') }}
+      - if: ${{ contains(matrix.e2e-framework, 'cypress') }}
         name: Cache Cypress binaries
         id: cache-cypress
         uses: actions/cache@v4
@@ -141,7 +159,7 @@ jobs:
           key: ${{ runner.os }}-cypress-bin
           path: ${{ env.CYPRESS_CACHE_FOLDER }}
 
-      - if: ${{ contains(matrix.flag-for-e2e, '--playwright') }}
+      - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
         name: Cache Playwright's binary
         uses: actions/cache@v4
         with:
@@ -150,47 +168,26 @@ jobs:
           key: ${{ runner.os }}-playwright-bin-v1
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
 
-      - if: ${{ (contains(env.FEATURE_FLAGS, '--')) }}
-        name: Create the sample project with feature flags
-        working-directory: ../
-        run: node ./create-vue/outfile.cjs sample-project ${{ env.FEATURE_FLAGS }}
-
-      - if: ${{ !(contains(env.FEATURE_FLAGS, '--')) }}
-        name: Create the sample project with default options
-        working-directory: ../
-        run: node ./create-vue/outfile.cjs sample-project --default
-
-      - name: Install dependencies in the sample project
-        working-directory: ../sample-project
-        run: pnpm install
-
-      - if: ${{ contains(matrix.flag-for-vitest, '--') }}
-        name: Run unit test script
-        working-directory: ../sample-project
-        run: pnpm test:unit
-
-      - name: Run build script
-        working-directory: ../sample-project
-        run: pnpm build
-
       - name: Download Cypress
-        if: ${{ contains(matrix.flag-for-e2e, '--cypress') }}
-        working-directory: ../sample-project
+        if: ${{ contains(matrix.e2e-framework, 'cypress') }}
+        working-directory: ./playground
         run: |
           pnpm exec cypress cache list
           pnpm exec cypress install
 
-      - if: ${{ contains(matrix.flag-for-e2e, '--playwright') }}
+      - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
         name: Install Playwright dependencies
-        working-directory: ../sample-project
+        working-directory: ./playground
         run: npx playwright install --with-deps
 
-      - if: ${{ contains(matrix.flag-for-e2e, '--') }}
-        name: Run e2e test script
-        working-directory: ../sample-project
-        run: pnpm test:e2e
+      # Run `test:e2e` in project folders contain `matrix.e2e-framework`
+      - name: Run e2e test script
+        working-directory: ./playground
+        run: pnpm --filter "{*${{ matrix.e2e-framework }}*}" test:e2e
 
-      - if: ${{ contains(matrix.flag-for-eslint, '--') }}
-        name: Run lint script
-        working-directory: ../sample-project
-        run: pnpm lint --no-fix --max-warnings=0
+      # FIXME: `--with-tests` folders
+      # FIXME: Cypress component testing for projects without Vitest
+
+
+  # FIXME: test-lint
+  # `pnpm lint --no-fix --max-warnings=0`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,19 @@ jobs:
             playground
           retention-days: 3
 
-  verify-build:
+  verify-scripts:
       needs: build
       strategy:
         matrix:
-          node-version: [22]
+          node-version: [18, 20, 22]
           os: [ubuntu-latest, windows-latest, macos-latest]
+          verification-script:
+            - pnpm --filter "\!*typescript*" build
+            - pnpm --filter "*typescript*" build
+            - pnpm --filter "*vitest*" test:unit
+            # FIXME: it's failing now
+            # - pnpm --filter "*with-tests*" test:unit
+            # TODO: lint
       runs-on: ${{ matrix.os }}
       continue-on-error: ${{ matrix.os == 'windows-latest' }}
       env:
@@ -76,129 +83,88 @@ jobs:
 
         - name: Run build script in playground
           working-directory: ./playground
-          run: pnpm --filter "\!*typescript*" build
+          run: ${{ matrix.verification-script }}
 
-  # verify-vitest:
-  #   # needs: build
-  #   strategy:
-  #     matrix:
-  #       node-version: [22]
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   runs-on: ${{ matrix.os }}
-  #   continue-on-error: ${{ matrix.os == 'windows-latest' }}
-  #   env:
-  #     CYPRESS_INSTALL_BINARY: 0
-  #     CHROMEDRIVER_SKIP_DOWNLOAD: true
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: true
-  #     - uses: pnpm/action-setup@v4
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'pnpm'
+  verify-e2e:
+    needs: build
+    strategy:
+      matrix:
+        e2e-framework: ['cypress', 'playwright']
+        node-version: [22]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    env:
+      # Sometimes the Linux runner can't verify Cypress in 30s
+      CYPRESS_VERIFY_TIMEOUT: 60000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
 
-  #     # FIXME: use artifacts to share the playground across different jobs
-  #     - name: Build the package
-  #       run: pnpm install && pnpm build && pnpm snapshot
-  #     - name: Install dependencies in playground
-  #       working-directory: ./playground
-  #       run: pnpm install --no-frozen-lockfile
+      - uses: actions/cache/restore@v4
+        id: cache-restore
+        with:
+          path: outfile.cjs
+          key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Build the package on cache miss
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: pnpm install && pnpm build
+      - name: Snapshot
+        run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
+      - name: Install dependencies in playground
+        working-directory: ../playground
+        run: pnpm install --no-frozen-lockfile
 
-  #     - name: Run test:unit script in vitest projects
-  #       working-directory: ../playground
-  #       run: pnpm --filter "{*vitest*}" test:unit
+      # https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml#L62
+      # Install playwright's binary under custom directory to cache
+      - name: Set Playwright & Cypress path
+        run: |
+          echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $GITHUB_ENV
+          echo "CYPRESS_CACHE_FOLDER=$HOME/.cache/cypress-bin" >> $GITHUB_ENV
+      - name: Set Playwright & Cypress path (windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "PLAYWRIGHT_BROWSERS_PATH=$HOME\.cache\playwright-bin" >> $env:GITHUB_ENV
+          echo "CYPRESS_CACHE_FOLDER=$HOME\.cache\cypress-bin" >> $env:GITHUB_ENV
 
-  #     # FIXME: it's failing now
-  #     # - name: Run test:unit script in with-tests projects
-  #     #   working-directory: ../playground
-  #     #   run: pnpm --filter "{*with-tests*}" test:unit
+      - if: ${{ contains(matrix.e2e-framework, 'cypress') }}
+        name: Cache Cypress binaries
+        id: cache-cypress
+        uses: actions/cache@v4
+        with:
+          # TODO: avoid snowballing by adding version
+          key: ${{ runner.os }}-cypress-bin
+          path: ${{ env.CYPRESS_CACHE_FOLDER }}
 
-  # verify-e2e:
-  #   needs: build
-  #   strategy:
-  #     matrix:
-  #       e2e-framework: ['cypress', 'playwright']
-  #       node-version: [22]
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   runs-on: ${{ matrix.os }}
-  #   continue-on-error: ${{ matrix.os == 'windows-latest' }}
-  #   env:
-  #     # Sometimes the Linux runner can't verify Cypress in 30s
-  #     CYPRESS_VERIFY_TIMEOUT: 60000
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: pnpm/action-setup@v3
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'pnpm'
+      - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
+        name: Cache Playwright's binary
+        uses: actions/cache@v4
+        with:
+          # Playwright removes unused browsers automatically
+          # So does not need to add playwright version to key
+          key: ${{ runner.os }}-playwright-bin-v1
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
 
-  #     - uses: actions/cache/restore@v4
-  #       id: cache-restore
-  #       with:
-  #         path: outfile.cjs
-  #         key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
-  #     - name: Build the package on cache miss
-  #       if: steps.cache-restore.outputs.cache-hit != 'true'
-  #       run: pnpm install && pnpm build
-  #     - name: Snapshot
-  #       run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
-  #     - name: Install dependencies in playground
-  #       working-directory: ../playground
-  #       run: pnpm install --no-frozen-lockfile
+      - name: Download Cypress
+        if: ${{ contains(matrix.e2e-framework, 'cypress') }}
+        working-directory: ../playground
+        run: |
+          pnpm --filter "{cypress}" exec cypress cache list
+          pnpm --filter "{cypress}" exec cypress install
 
-  #     # https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml#L62
-  #     # Install playwright's binary under custom directory to cache
-  #     - name: Set Playwright & Cypress path
-  #       run: |
-  #         echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $GITHUB_ENV
-  #         echo "CYPRESS_CACHE_FOLDER=$HOME/.cache/cypress-bin" >> $GITHUB_ENV
-  #     - name: Set Playwright & Cypress path (windows)
-  #       if: runner.os == 'Windows'
-  #       run: |
-  #         echo "PLAYWRIGHT_BROWSERS_PATH=$HOME\.cache\playwright-bin" >> $env:GITHUB_ENV
-  #         echo "CYPRESS_CACHE_FOLDER=$HOME\.cache\cypress-bin" >> $env:GITHUB_ENV
+      - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
+        name: Install Playwright dependencies
+        working-directory: ../playground
+        run: pnpm --filter "{playwright}" exec playwright install --with-deps
 
-  #     - if: ${{ contains(matrix.e2e-framework, 'cypress') }}
-  #       name: Cache Cypress binaries
-  #       id: cache-cypress
-  #       uses: actions/cache@v4
-  #       with:
-  #         # TODO: avoid snowballing by adding version
-  #         key: ${{ runner.os }}-cypress-bin
-  #         path: ${{ env.CYPRESS_CACHE_FOLDER }}
+      # Run `test:e2e` in project folders contain `matrix.e2e-framework`
+      - name: Run e2e test script
+        working-directory: ../playground
+        run: pnpm --filter "{*${{ matrix.e2e-framework }}*}" test:e2e
 
-  #     - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
-  #       name: Cache Playwright's binary
-  #       uses: actions/cache@v4
-  #       with:
-  #         # Playwright removes unused browsers automatically
-  #         # So does not need to add playwright version to key
-  #         key: ${{ runner.os }}-playwright-bin-v1
-  #         path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-
-  #     - name: Download Cypress
-  #       if: ${{ contains(matrix.e2e-framework, 'cypress') }}
-  #       working-directory: ../playground
-  #       run: |
-  #         pnpm --filter "{cypress}" exec cypress cache list
-  #         pnpm --filter "{cypress}" exec cypress install
-
-  #     - if: ${{ contains(matrix.e2e-framework, 'playwright') }}
-  #       name: Install Playwright dependencies
-  #       working-directory: ../playground
-  #       run: pnpm --filter "{playwright}" exec playwright install --with-deps
-
-  #     # Run `test:e2e` in project folders contain `matrix.e2e-framework`
-  #     - name: Run e2e test script
-  #       working-directory: ../playground
-  #       run: pnpm --filter "{*${{ matrix.e2e-framework }}*}" test:e2e
-
-  #     # FIXME: `--with-tests` folders
-  #     # FIXME: Cypress component testing for projects without Vitest
-
-
-  # # FIXME: verify-lint
-  # # `pnpm lint --no-fix --max-warnings=0`
+      # FIXME: `--with-tests` folders
+      # FIXME: Cypress component testing for projects without Vitest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         CHROMEDRIVER_SKIP_DOWNLOAD: true
       steps:
         - uses: actions/checkout@v4
+          with:
+            submodules: true
         - uses: pnpm/action-setup@v3
           with:
             standalone: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,40 +11,43 @@ on:
     branches:
       - '**'
 jobs:
-  # build:
-  #   runs-on: ubuntu-latest
-  #   name: Build the package
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: pnpm/action-setup@v3
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 22
-  #         cache: 'pnpm'
-  #     - run: pnpm install
-  #       env:
-  #         CYPRESS_INSTALL_BINARY: 0
-  #         CHROMEDRIVER_SKIP_DOWNLOAD: true
-  #     - run: pnpm build
-  #     - run: pnpm test:unit
+  build:
+    runs-on: ubuntu-latest
+    name: Build the package
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - run: pnpm install
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+          CHROMEDRIVER_SKIP_DOWNLOAD: true
+      - run: pnpm build
+      - run: pnpm test:unit
 
-  #     - run: pnpm snapshot
-  #     # Use cache to share the output across different jobs
-  #     # No need to cache node_modules because they are all bundled
-  #     - uses: actions/cache/save@v4
-  #       id: cache
-  #       with:
-  #         path: |
-  #           outfile.cjs
-  #           playground
-  #         key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
+      - run: pnpm snapshot
+
+      # Use artifact to share the output across different jobs
+      # No need to save node_modules because they are all bundled
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-output
+          path: |
+            outfile.cjs
+            playground
+          retention-days: 3
 
   test-build:
-      # needs: build
+      needs: build
       strategy:
         matrix:
           node-version: [22]
-          os: [ubuntu-latest]
+          os: [ubuntu-latest, windows-latest, macos-latest]
       runs-on: ${{ matrix.os }}
       continue-on-error: ${{ matrix.os == 'windows-latest' }}
       env:
@@ -54,33 +57,27 @@ jobs:
         - uses: actions/checkout@v4
           with:
             submodules: true
-        - uses: pnpm/action-setup@v3
-          with:
-            standalone: true
+        - uses: pnpm/action-setup@v4
         - uses: actions/setup-node@v4
           with:
             node-version: ${{ matrix.node-version }}
             cache: 'pnpm'
 
-        # - uses: actions/cache/restore@v4
-        #   id: cache-restore
-        #   with:
-        #     path: |
-        #       outfile.cjs
-        #       playground
-        #     key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
-        - name: Build the package
-          run: pnpm install && pnpm build && pnpm snapshot
-        - run: echo "{}" > playground/package.json
-        - run: mv playground playground-tmp
+        # use artifacts to share the playground across different jobs
+        - uses: actions/download-artifact@v2
+          with:
+            name: build-output
+
         - name: Install dependencies in playground
-          run: pnpm -C ./playground-tmp install --no-frozen-lockfile
+          working-directory: ./playground
+          run: pnpm install --no-frozen-lockfile
 
         - name: Run build script in playground
-          run: pnpm -C ./playground-tmp --filter "*" build
+          working-directory: ./playground
+          run: pnpm --filter "*" build
 
   # test-vitest:
-  #   needs: build
+  #   # needs: build
   #   strategy:
   #     matrix:
   #       node-version: [22]
@@ -92,25 +89,21 @@ jobs:
   #     CHROMEDRIVER_SKIP_DOWNLOAD: true
   #   steps:
   #     - uses: actions/checkout@v4
-  #     - uses: pnpm/action-setup@v3
+  #       with:
+  #         submodules: true
+  #     - uses: pnpm/action-setup@v4
   #     - uses: actions/setup-node@v4
   #       with:
   #         node-version: ${{ matrix.node-version }}
   #         cache: 'pnpm'
 
-  #     - uses: actions/cache/restore@v4
-  #       id: cache-restore
-  #       with:
-  #         path: outfile.cjs
-  #         key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
-  #     - name: Build the package on cache miss
-  #       if: steps.cache-restore.outputs.cache-hit != 'true'
-  #       run: pnpm install && pnpm build
-  #     - name: Snapshot
-  #       run: pnpm snapshot && echo "{}" > playground/package.json && mv playground ../playground
+  #     # FIXME: use artifacts to share the playground across different jobs
+  #     - name: Build the package
+  #       run: pnpm install && pnpm build && pnpm snapshot
   #     - name: Install dependencies in playground
-  #       working-directory: ../playground
+  #       working-directory: ./playground
   #       run: pnpm install --no-frozen-lockfile
+
   #     - name: Run test:unit script in vitest projects
   #       working-directory: ../playground
   #       run: pnpm --filter "{*vitest*}" test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        e2e-framework: ['cypress', 'playwright', 'nightwatch']
+        e2e-framework: ['cypress', 'playwright']
         node-version: [22]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -169,7 +169,7 @@ jobs:
         run: pnpm --filter "*${{ matrix.e2e-framework }}*" --workspace-concurrency 1 test:e2e
 
       - name: Cypress component testing for projects without Vitest
-        if: ${{ contains(matrix.e2e-framework, 'cypress') || contains(matrix.e2e-framework, 'nightwatch') }}
+        if: ${{ contains(matrix.e2e-framework, 'cypress') }}
         run: pnpm --filter '*cypress*' --filter '!*vitest*' --workspace-concurrency 1 test:unit
 
       # FIXME: `--with-tests` folders. It's failing now.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
         - name: Build the package on cache miss
           if: steps.cache-restore.outputs.cache-hit != 'true'
-          run: pnpm install && pnpm build && pnpm snapshot
+          run: pnpm install && pnpm build && pnpm snapshot && echo "{}" > playground/package.json
         - name: Move playground to an outside directory to work around working-directory issue
           if: steps.cache-restore.outputs.cache-hit != 'true'
           run: mv playground ../playground
@@ -104,7 +104,7 @@ jobs:
           key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Build the package on cache miss
         if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: pnpm install && pnpm build && pnpm snapshot
+        run: pnpm install && pnpm build && pnpm snapshot && echo "{}" > playground/package.json
       - name: Move playground to an outside directory to work around working-directory issue
         if: steps.cache-restore.outputs.cache-hit != 'true'
         run: mv playground ../playground
@@ -149,7 +149,7 @@ jobs:
           key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Build the package on cache miss
         if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: pnpm install && pnpm build && pnpm snapshot
+        run: pnpm install && pnpm build && pnpm snapshot && echo "{}" > playground/package.json
       - name: Move playground to an outside directory to work around working-directory issue
         if: steps.cache-restore.outputs.cache-hit != 'true'
         run: mv playground ../playground

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,5 +168,8 @@ jobs:
         working-directory: ./playground
         run: pnpm --filter "*${{ matrix.e2e-framework }}*" --workspace-concurrency 1 test:e2e
 
-      # FIXME: `--with-tests` folders
-      # FIXME: Cypress component testing for projects without Vitest
+      - name: Cypress component testing for projects without Vitest
+        if: ${{ contains(matrix.e2e-framework, 'cypress') }}
+        run: pnpm --filter '*cypress*' --filter '!*vitest*' --workspace-concurrency 1 test:unit
+
+      # FIXME: `--with-tests` folders. It's failing now.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,13 +67,12 @@ jobs:
             key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
         - name: Build the package on cache miss
           run: pnpm install && pnpm build && pnpm snapshot
-        - name: Move playground to work around weird working-directory issue
-          run: rm playground/pnpm-lock.yaml && mv playground ../playground
+        - run: echo "{}" > playground/package.json
         - name: Install dependencies in playground
-          run: pnpm -C ../playground install --no-frozen-lockfile
+          run: pnpm -C ./playground install --no-frozen-lockfile
 
         - name: Run build script in playground
-          run: pnpm -C ../playground --filter "*" build
+          run: pnpm -C ./playground --filter "*" build
 
   # test-vitest:
   #   needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Run e2e test script
         working-directory: ./playground
-        run: pnpm --filter --workspace-concurrency 1 "*${{ matrix.e2e-framework }}*" test:e2e
+        run: pnpm --filter "*${{ matrix.e2e-framework }}*" --workspace-concurrency 1 test:e2e
 
       # FIXME: `--with-tests` folders
       # FIXME: Cypress component testing for projects without Vitest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         - name: Build the package on cache miss
           run: pnpm install && pnpm build && pnpm snapshot
         - name: Move playground to work around weird working-directory issue
-          run: rm playgroun/pnpm-lock.yaml && mv playground ../playground
+          run: rm playground/pnpm-lock.yaml && mv playground ../playground
         - name: Install dependencies in playground
           run: pnpm -C ../playground install --no-frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           run: echo "{}" > playground/package.json && mv playground ../playground
         - name: Install dependencies in playground
           working-directory: ../playground
-          run: pnpm install --no-frozen-lockfile
+          run: pnpm install --no-frozen-lockfile -r
 
         - name: Run build script in playground
           working-directory: ../playground

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         - name: Build the package on cache miss
           run: pnpm install && pnpm build && pnpm snapshot
         - name: Move playground to work around weird working-directory issue
-          run: mv playground ../playground
+          run: rm playgroun/pnpm-lock.yaml && mv playground ../playground
         - name: Install dependencies in playground
           run: pnpm -C ../playground install --no-frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
           with:
             name: build-output
 
+        - name: Install dependencies to avoid tsconfig warnings
+          run: pnpm install
         - name: Install dependencies in playground
           working-directory: ./playground
           run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       strategy:
         matrix:
           node-version: [22]
-          os: [ubuntu-latest, windows-latest, macos-latest]
+          os: [ubuntu-latest]
       runs-on: ${{ matrix.os }}
       continue-on-error: ${{ matrix.os == 'windows-latest' }}
       env:
@@ -71,7 +71,7 @@ jobs:
           run: mv playground ../playground
         - name: Install dependencies in playground
           working-directory: ../playground
-          run: pnpm install --no-frozen-lockfile -r
+          run: pnpm recursive install --no-frozen-lockfile
 
         - name: Run build script in playground
           working-directory: ../playground

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       # Use artifact to share the output across different jobs
       # No need to save node_modules because they are all bundled
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: build-output
           path: |
@@ -64,7 +64,7 @@ jobs:
             cache: 'pnpm'
 
         # use artifacts to share the playground across different jobs
-        - uses: actions/download-artifact@v2
+        - uses: actions/download-artifact@v4
           with:
             name: build-output
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,12 @@ jobs:
         - name: Build the package
           run: pnpm install && pnpm build && pnpm snapshot
         - run: echo "{}" > playground/package.json
+        - run: mv playground playground-tmp
         - name: Install dependencies in playground
-          run: pnpm -C ./playground install --no-frozen-lockfile
+          run: pnpm -C ./playground-tmp install --no-frozen-lockfile
 
         - name: Run build script in playground
-          run: pnpm -C ./playground --filter "*" build
+          run: pnpm -C ./playground-tmp --filter "*" build
 
   # test-vitest:
   #   needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - uses: pnpm/action-setup@v3
+          with:
+            standalone: true
         - uses: actions/setup-node@v4
           with:
             node-version: ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
         - name: Run build script in playground
           working-directory: ./playground
-          run: pnpm --filter "*" build
+          run: pnpm --filter "\!*typescript*" build
 
   # verify-vitest:
   #   # needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
         - uses: actions/cache/restore@v4
           id: cache-restore
           with:
-            path: outfile.cjs
+            path: |
+              outfile.cjs
+              playground
             key: ${{ github.sha }}-${{ hashFiles('pnpm-lock.yaml') }}
         - name: Build the package on cache miss
           run: pnpm install && pnpm build && pnpm snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Run e2e test script
         working-directory: ./playground
-        run: pnpm --filter "*${{ matrix.e2e-framework }}*" test:e2e
+        run: pnpm --filter --workspace-concurrency 1 "*${{ matrix.e2e-framework }}*" test:e2e
 
       # FIXME: `--with-tests` folders
       # FIXME: Cypress component testing for projects without Vitest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             playground
           retention-days: 3
 
-  test-build:
+  verify-build:
       needs: build
       strategy:
         matrix:
@@ -78,7 +78,7 @@ jobs:
           working-directory: ./playground
           run: pnpm --filter "*" build
 
-  # test-vitest:
+  # verify-vitest:
   #   # needs: build
   #   strategy:
   #     matrix:
@@ -115,7 +115,7 @@ jobs:
   #     #   working-directory: ../playground
   #     #   run: pnpm --filter "{*with-tests*}" test:unit
 
-  # test-e2e:
+  # verify-e2e:
   #   needs: build
   #   strategy:
   #     matrix:
@@ -200,5 +200,5 @@ jobs:
   #     # FIXME: Cypress component testing for projects without Vitest
 
 
-  # # FIXME: test-lint
+  # # FIXME: verify-lint
   # # `pnpm lint --no-fix --max-warnings=0`


### PR DESCRIPTION
### Description

Simplify the CI pipeline for a cleaner workflow; and avoid the parallelism limit when we add more flags to the CLI.

Most of the time, the new workflow's total duration would be shorter or similar to the previous one (longer job execution time but less queueing time[^1]), but sometimes, Windows Cypress tests took too long when cache misses.

TODOs:
- [x] separate `typescript-*` projects from others because type-checking takes much more time
- [x] add node 18/20 jobs
- [ ] ~~add tests for Nightwatch~~ I didn't manage to get Nightwatch tests working on GitHub Actions. It was never tested before anyway, so let's skip that for this PR.
- [ ] Add more snapshots for ESLint / Prettier, now that they won't trigger more jobs in the CI matrix.
	I'd like to move that into a separate PR because it requires changing the snapshot script, so not a mere CI change.
- [ ] fix `--with-tests`. That should also be a separate PR.

TO DECIDE:
- [ ] Shall we scope down the Node.js 18/20 tests to only make sure that the project can be successfully created and dependencies can be installed with `engine-strict` flag on? Because most of the actual compatibility work is on the shoulder of the upstream projects, not us.

[^1]: there can be only 20 concurrent jobs on [GitHub Free plan](https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits)