### PR TITLE
fix: extend `Intl.getCanonicalLocales` error message

### DIFF
--- a/utils/getLanguage.ts
+++ b/utils/getLanguage.ts
@@ -55,7 +55,7 @@ function linkLocale(locale: string) {
   try {
     linkedLocale = Intl.getCanonicalLocales(locale)[0]
   } catch (error) {
-    console.log(`${error.toString()}\n`)
+    console.log(`${error.toString()}, invalid language tag: "${locale}"\n`)
   }
   switch (linkedLocale) {
     case 'zh-TW':


### PR DESCRIPTION
### Description

In different environments, the error message output by this API is inconsistent. refer https://github.com/mdn/interactive-examples/pull/2741#issuecomment-1961443468
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->
