### PR TITLE
fix: correct the command to show help in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ npm create vue@latest
 
 By default the command will run in interactive mode, but you can also provide feature flags in the CLI arguments to skip the prompts. Run `npm create vue@latest -- --help` to see all available options.
 
+> [!NOTE]
+> If you're using PowerShell, you'll need to quote the `--`, that is, run `npm create vue@latest '--' --help`.
+
 If you need to support IE11, you can create a Vue 2 project with:
 
 ```sh


### PR DESCRIPTION
The old command will show the help of `npm create`, not the help of `create-vue`.

### Description

Current documentation says we can use `npm create vue@latest -- --help` to show the help of `create-vue`, but I found it will print the help of `npm create`. I'm not sure if it's a bug of `npm`, but `npx create-vue@latest -- --help` works fine.

### My Enviroment

Windows 11 + npm 10.9.0

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->
