### PR TITLE
fix: add `cypress install` to `prepare` script to fix pnpm 10 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Install dependencies in playground
         working-directory: ./playground
         run: pnpm install --no-frozen-lockfile
+        env:
+          # Skip Cypress installation temporarily, we'll install it later with cache
+          CYPRESS_INSTALL_BINARY: 0
 
       # https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml#L62
       # Install playwright's binary under custom directory to cache

--- a/template/config/cypress/package.json
+++ b/template/config/cypress/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "prepare": "cypress install",
     "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
     "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'"
   },


### PR DESCRIPTION
This approach works with both pnpm 10 and other package managers:
- If Cypress's `postinstall` script has been run, it'll do nothing other than print a message.
- If `postinstall` hasn't been run, it'll download the Cypress binary.

As for why using `prepare` instead of `postinstall`, please refer to the discussion thread where `husky` decided to use `prepare`:
- <https://github.com/typicode/husky/issues/884>