### PR TITLE
fix: correctly set the package name value

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -386,7 +386,7 @@ async function init() {
   // so we still have to assign the default values here
   const {
     projectName,
-    packageName = projectName ?? defaultProjectName,
+    packageName = projectName.trim() || defaultProjectName,
     shouldOverwrite = argv.force as boolean,
     needsJsx = argv.jsx as boolean,
     needsTypeScript = (argv.ts || argv.typescript) as boolean,


### PR DESCRIPTION
### Description
When the projectName is set to a string containing only spaces, the value of the package name field must be set correctly.
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->
