### PR TITLE
fix: vitest merge config in form of callback

### DIFF
--- a/template/config/vitest/vitest.config.js
+++ b/template/config/vitest/vitest.config.js
@@ -2,8 +2,8 @@ import { fileURLToPath } from 'node:url'
 import { mergeConfig, defineConfig, configDefaults } from 'vitest/config'
 import viteConfig from './vite.config'
 
-export default mergeConfig(
-  viteConfig,
+export default defineConfig(configEnv => mergeConfig(
+  viteConfig(configEnv),
   defineConfig({
     test: {
       environment: 'jsdom',
@@ -11,4 +11,4 @@ export default mergeConfig(
       root: fileURLToPath(new URL('./', import.meta.url)),
     },
   }),
-)
+))


### PR DESCRIPTION
I got an vitest error using `create-vue` template:

> Error: Vitest failed to start: 
> Error: Cannot merge config in form of callback
>   at mergeConfig (file://...)

Fixed it according to [vitest's official documentation](https://vitest.dev/config/#configuration)

<img width="677" alt="image" src="https://github.com/user-attachments/assets/1ae80d53-1086-446d-b622-a89d2965da1e" />
