### PR TITLE
chore(config): moving prettier script inside the script section

### DIFF
--- a/template/config/prettier/package.json
+++ b/template/config/prettier/package.json
@@ -1,5 +1,7 @@
 {
-  "format": "prettier --write src/",
+  "scripts": {
+    "format": "prettier --write src/"
+  },
   "devDependencies": {
     "prettier": "3.5.3"
   }


### PR DESCRIPTION
### Description

I noticed that after a project creation, there's a `format` outside of the scripts. That should be caused by the prettier configuration script.

This PR solves that small issue. 