### PR TITLE
fix: compatible with lower version node

### DIFF
--- a/utils/getLanguage.ts
+++ b/utils/getLanguage.ts
@@ -107,7 +107,12 @@ function getLocale() {
 }
 
 async function loadLanguageFile(filePath: string): Promise<Language> {
-  return (await import(pathToFileURL(filePath).toString(), { with: { type: 'json' } })).default
+  return await fs.promises.readFile(filePath, 'utf-8').then((data) => {
+    const parsedData = JSON.parse(data)
+    if (parsedData) {
+      return parsedData
+    }
+  })
 }
 
 export default async function getLanguage(localesRoot: string) {


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->
fix #731

`with {type: 'json'}` requires node version 20.10 or later to support.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#browser_compatibility