### PR TITLE
chore: align Node version with Vite 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "!template/**/node_modules/.bin/*"
   ],
   "engines": {
-    "node": ">=v20.0.0"
+    "node": "^20.19.0 || >=22.12.0"
   },
   "scripts": {
     "prepare": "husky",


### PR DESCRIPTION
Vite 7 requires Node versions 20.19+ or 22.12+. [Vite docs](https://vite.dev/guide/migration.html).

With older versions of Node, starting the dev server will yield an error:

> crypto.hash is not a function

More details: <https://github.com/vitejs/vite/issues/20287>.

I've aligned the `engines.node` value with `create-vite`:

https://github.com/vitejs/vite/blob/3e81af38a80c7617aba6bf3300d8b4267570f9cf/packages/create-vite/package.json#L23

While `create-vue` itself doesn't require these Node versions, I think it makes sense to align `engines.node` with versions that can run the created project.