### PR TITLE
ci: skip Windows + Cypress temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,11 @@ jobs:
         e2e-framework: ['cypress', 'playwright']
         node-version: [22]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          # Temporarily exclude Windows + Cypress due to EPERM issues with start-server-and-test
+          # FIXME: move away from `start-server-and-test`
+          - os: windows-latest
+            e2e-framework: cypress
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.os == 'windows-latest' }}
     env:


### PR DESCRIPTION
I thought it was just random timeouts until I look into the logs and found that it's always the same EPERM error on Windows.

It has been reported to us before that EPERM errors are happening on Windows + Cypress projects. The issue was later moved to the `start-server-and-test` repository but it is still not resolved. <https://github.com/bahmutov/start-server-and-test/issues/384>

Furthermore, Windows 11 24H2 and Windows Server 2025 have removed the `wmic` utility, which is used by `start-server-and-test` (via the `ps-tree` dependency). Once GitHub Actions upgrades the `latest` tag to Windows Server 2025, `start-server-and-test` will break completely on our CI.

`start-server-and-test` and `ps-tree` are largely unmaintained, so we need to move away from `start-server-and-test` in the near future and then we can re-enable Windows + Cypress tests.

