### PR TITLE
docs: add browser setup instructions in the generated README [skip ci]

### DIFF
--- a/utils/generateReadme.ts
+++ b/utils/generateReadme.ts
@@ -35,10 +35,10 @@ This template should help get you started developing with Vue 3 in Vite.
 
 - Chromium-based browsers (Chrome, Edge, Brave, etc.):
   - [Vue.js devtools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd) 
-  - [Turn on Custom Object Formmater in Chrome DevTools](http://bit.ly/object-formatters)
+  - [Turn on Custom Object Formatter in Chrome DevTools](http://bit.ly/object-formatters)
 - Firefox:
   - [Vue.js devtools](https://addons.mozilla.org/en-US/firefox/addon/vue-js-devtools/)
-  - [Turn on Custom Object Formmater in Firefox DevTools](https://fxdx.dev/firefox-devtools-custom-object-formatters/)
+  - [Turn on Custom Object Formatter in Firefox DevTools](https://fxdx.dev/firefox-devtools-custom-object-formatters/)
 ${needsTypeScript ? sfcTypeSupportDoc : ''}
 ## Customize configuration
 


### PR DESCRIPTION
I find that there are still many users who are not aware of the [custom object formatter feature](https://x.com/youyuxi/status/1316043978597376000) so I added the instructions for more visibility.
