### PR TITLE
chore: use pnpm v10 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9.15.9
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,8 @@ packages:
   - template/tsconfig/**
 
 ignoredBuiltDependencies:
+  - '@nightwatch/nightwatch-inspector'
   - chromedriver
   - cypress
+  - esbuild
+  - geckodriver


### PR DESCRIPTION
### Description

This is already the case in other CI workflows, and should fix https://github.com/vuejs/create-vue/pull/801/
