### PR TITLE
fix: Correct "build" command in package.json

### DIFF
--- a/template/config/typescript/package.json
+++ b/template/config/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "run-p build-only \"type-check {@}\" --",
+    "build": "run-p build-only {@}\"type-check \" --",
     "build-only": "vite build",
     "type-check": "vue-tsc --build"
   },


### PR DESCRIPTION
some d.ts files will generate after build. type-check fails when those files aren't generated. That is why we should build first.