### PR TITLE
fix(vitest): ignore __screenshots__ directory

### DIFF
--- a/template/base/_gitignore
+++ b/template/base/_gitignore
@@ -14,9 +14,6 @@ dist-ssr
 coverage
 *.local
 
-/cypress/videos/
-/cypress/screenshots/
-
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
@@ -28,3 +25,10 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+
+# Cypress
+/cypress/videos/
+/cypress/screenshots/
+
+# Vitest
+__screenshots__/


### PR DESCRIPTION
### Description

When used in browser mode, Vitest generates `__screenshots__` directories in `__tests__` for failing tests.