### PR TITLE
feat: migrate vscode default formatter from `esbenp.prettier-vscode` to `prettier.prettier-vscode`

### DIFF
--- a/template/config/prettier/.vscode/extensions.json
+++ b/template/config/prettier/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["esbenp.prettier-vscode"]
+  "recommendations": ["prettier.prettier-vscode"]
 }

--- a/template/config/prettier/.vscode/settings.json
+++ b/template/config/prettier/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "prettier.prettier-vscode"
 }


### PR DESCRIPTION
### Description

migrate vscode default formatter from `esbenp.prettier-vscode` to `prettier.prettier-vscode` since the extension is being moved in vscode marketplace

see:
- https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
- https://github.com/prettier/prettier-vscode

---

<img width="1113" height="641" alt="image" src="https://github.com/user-attachments/assets/2199a30b-d229-42c4-87e4-f57bedb9da34" />
