### PR TITLE
remove trailing whitespace in README.md

### DIFF
--- a/utils/generateReadme.ts
+++ b/utils/generateReadme.ts
@@ -34,7 +34,7 @@ This template should help get you started developing with Vue 3 in Vite.
 ## Recommended Browser Setup
 
 - Chromium-based browsers (Chrome, Edge, Brave, etc.):
-  - [Vue.js devtools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd) 
+  - [Vue.js devtools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)
   - [Turn on Custom Object Formatter in Chrome DevTools](http://bit.ly/object-formatters)
 - Firefox:
   - [Vue.js devtools](https://addons.mozilla.org/en-US/firefox/addon/vue-js-devtools/)


### PR DESCRIPTION
### Description

There is an exrea trailing whitespace in generated vue project's README.md, this commit remove the whitespace.

https://github.com/vuejs/create-vue/blob/6e3b2168a8b4a6176b65d4d97ec7610e6388c110/utils/generateReadme.ts#L37