### PR TITLE
feat: oxlint config add `ignorePatterns`

### DIFF
--- a/template/linting/oxlint/_oxlintrc.json
+++ b/template/linting/oxlint/_oxlintrc.json
@@ -6,5 +6,6 @@
   },
   "categories": {
     "correctness": "error"
-  }
+  },
+  "ignorePatterns": ["dist/**", "node_modules/**"]
 }


### PR DESCRIPTION
### Description
It appears that oxlint does not exclude node_modules by default.
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->
