### PR TITLE
feat: use vite 8 beta instead of rolldown-vite package

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -44,7 +44,7 @@ const FEATURE_FLAGS = [
   'prettier',
   'eslint-with-prettier',
   'oxlint',
-  'rolldown-vite',
+  'vite-beta',
 ] as const
 
 const FEATURE_OPTIONS = [
@@ -87,8 +87,8 @@ const EXPERIMENTAL_FEATURE_OPTIONS = [
     label: language.needsOxlint.message,
   },
   {
-    value: 'rolldown-vite',
-    label: language.needsRolldownVite.message,
+    value: 'vite-beta',
+    label: language.needsViteBeta.message,
   },
 ] as const
 
@@ -199,8 +199,8 @@ Available feature flags:
     Add Prettier for code formatting.
   --oxlint
     Add Oxlint for code quality and formatting.
-  --rolldown-vite
-    Use Rolldown Vite instead of Vite for building the project.
+  --vite-beta
+    Use Vite 8 Beta instead of Vite for building the project.
 
 Unstable feature flags:
   --tests, --with-tests
@@ -378,7 +378,8 @@ async function init() {
   const needsPrettier =
     argv.prettier || argv['eslint-with-prettier'] || features.includes('prettier')
   const needsOxlint = experimentFeatures.includes('oxlint') || argv['oxlint']
-  const needsRolldownVite = experimentFeatures.includes('rolldown-vite') || argv['rolldown-vite']
+  const needsViteBeta =
+    experimentFeatures.includes('vite-beta') || argv['vite-beta'] || argv['rolldown-vite'] // keep `rolldown-vite` for backward compatibility
 
   const { e2eFramework } = result
   const needsCypress = argv.cypress || argv.tests || e2eFramework === 'cypress'
@@ -409,8 +410,8 @@ async function init() {
   const replaceVite = () => {
     const content = fs.readFileSync(path.resolve(root, 'package.json'), 'utf-8')
     const json = JSON.parse(content)
-    // Replace `vite` with `rolldown-vite` if the feature is enabled
-    json.devDependencies.vite = 'npm:rolldown-vite@latest'
+    // Replace `vite` version with beta if the feature is enabled
+    json.devDependencies.vite = 'beta'
     fs.writeFileSync(path.resolve(root, 'package.json'), JSON.stringify(json, null, 2))
   }
   // Render base template
@@ -546,8 +547,8 @@ async function init() {
     // TODO: add oxfmt option in the next PR
   }
 
-  // use rolldown-vite if the feature is enabled
-  if (needsRolldownVite) {
+  // use Vite 8 Beta if the feature is enabled
+  if (needsViteBeta) {
     replaceVite()
   }
 

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -69,8 +69,8 @@
     "message": "Select experimental features to include in your project:",
     "hint": "(↑/↓ to navigate, space to select, a to toggle all, enter to confirm)"
   },
-  "needsRolldownVite": {
-    "message": "rolldown-vite (experimental)"
+  "needsViteBeta": {
+    "message": "Vite 8 (beta)"
   },
   "needsBareboneTemplates": {
     "message": "Skip all example code and start with a blank Vue project?"

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -69,8 +69,8 @@
     "message": "Sélectionnez les fonctionnalités expérimentales à inclure\u00a0:",
     "hint": "(↑/↓ pour naviguer, espace pour sélectionner, a pour tout sélectionner, entrée pour confirmer)"
   },
-  "needsRolldownVite": {
-    "message": "rolldown-vite (expérimental)"
+  "needsViteBeta": {
+    "message": "Vite 8 (beta)"
   },
   "needsBareboneTemplates": {
     "message": "Ignorer tout le code d'exemple et commencer avec un projet Vue vierge\u00a0?"

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -69,8 +69,8 @@
     "message": "Dahil edilecek deneysel özellikleri seçin:",
     "hint": "(↑/↓ gezinmek için, boşluk seçmek için, a tümünü seçmek için, enter onaylamak için)"
   },
-  "needsRolldownVite": {
-    "message": "rolldown-vite (deneysel)"
+  "needsViteBeta": {
+    "message": "Vite 8 (beta)"
   },
   "needsBareboneTemplates": {
     "message": "Tüm örnek kodları atlayıp boş bir Vue projesi ile başlansın mı?"

--- a/locales/zh-Hans.json
+++ b/locales/zh-Hans.json
@@ -69,8 +69,8 @@
     "message": "选择要包含的试验特性：",
     "hint": "(↑/↓ 切换，空格选择，a 全选，回车确认)"
   },
-  "needsRolldownVite": {
-    "message": "rolldown-vite（试验阶段）"
+  "needsViteBeta": {
+    "message": "Vite 8（测试版）"
   },
   "needsBareboneTemplates": {
     "message": "跳过所有示例代码，创建一个空白的 Vue 项目？"

--- a/locales/zh-Hant.json
+++ b/locales/zh-Hant.json
@@ -69,8 +69,8 @@
     "message": "請選擇要包含的試驗特性：",
     "hint": "(↑/↓ 切換，空格選擇，a 全選，enter 確認)"
   },
-  "needsRolldownVite": {
-    "message": "rolldown-vite（試驗性功能）"
+  "needsViteBeta": {
+    "message": "Vite 8（測試版）"
   },
   "needsBareboneTemplates": {
     "message": "跳過所有範例程式碼，建立一個空白的 Vue 專案？"

--- a/utils/getLanguage.ts
+++ b/utils/getLanguage.ts
@@ -39,7 +39,7 @@ interface Language {
   needsExperimental: LanguageItem
   needsExperimentalFeatures: LanguageItem
   needsOxlint: LanguageItem
-  needsRolldownVite: LanguageItem
+  needsViteBeta: LanguageItem
   needsBareboneTemplates: LanguageItem
   errors: {
     operationCancelled: string


### PR DESCRIPTION
### Description

Use Vite 8 beta instead of rolldown-vite when using the experimental feature.
The rolldown-vite flag is kept for bw-compat	