### PR TITLE
fix: revert Prettier VS Code extension ID to `esbenp.prettier-vscode` [skip ci]

### DIFF
--- a/template/formatting/prettier/.vscode/extensions.json
+++ b/template/formatting/prettier/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["prettier.prettier-vscode"]
+  "recommendations": ["esbenp.prettier-vscode"]
 }

--- a/template/formatting/prettier/.vscode/settings.json
+++ b/template/formatting/prettier/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "prettier.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
The "Prettier (New)" extension with the ID `prettier.prettier-vscode` is deprecated now and we need to switch to the original extension again.

https://github.com/prettier/prettier-vscode/issues/3872#issuecomment-3662898646

