### PR TITLE
fix(oxlint): do not add typescript plugin to js project

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -541,6 +541,11 @@ async function init() {
 
     // These configs only disable rules, so they should be applied last.
     render('linting/oxlint')
+    // Provide data for the oxlintrc.json template
+    callbacks.push(async (dataStore) => {
+      const oxlintrcPath = path.resolve(root, '.oxlintrc.json')
+      dataStore[oxlintrcPath] = { needsTypeScript }
+    })
     if (needsPrettier || needsOxfmt) {
       render('linting/formatter')
     }

--- a/template/linting/oxlint/_oxlintrc.json.ejs
+++ b/template/linting/oxlint/_oxlintrc.json.ejs
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["eslint", "typescript", "unicorn", "oxc", "vue"],
+  "plugins": ["eslint"<%_ if (needsTypeScript) { _%>, "typescript"<%_ } _%>, "unicorn", "oxc", "vue"],
   "env": {
     "browser": true
   },


### PR DESCRIPTION
### Description

This adds the typescript oxlint plugin to the generated config only for TS project (and opens the door to adding other plugins conditionally too)