### PR TITLE
fix(oxlint): use buildFromOxlintConfigFile in eslint config

### DIFF
--- a/template/linting/oxlint/eslint.config.js.data.mjs
+++ b/template/linting/oxlint/eslint.config.js.data.mjs
@@ -5,7 +5,7 @@ export default function getData({ oldData }) {
       ...oldData.configs,
       {
         importer: `import pluginOxlint from 'eslint-plugin-oxlint'`,
-        content: `\n  ...pluginOxlint.configs['flat/recommended'],`,
+        content: `\n  ...pluginOxlint.buildFromOxlintConfigFile('.oxlintrc.json'),`,
       },
     ],
   }


### PR DESCRIPTION
### Description

See https://www.npmjs.com/package/eslint-plugin-oxlint

I think it might be better than using recommended if the users wants to personalize their oxlint config?