### PR TITLE
fix: add missing oxfmt CLI flag

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -50,6 +50,7 @@ const FEATURE_FLAGS = [
   'prettier',
   'eslint-with-prettier',
   'oxlint',
+  'oxfmt',
   'vite-beta',
   'vue-beta',
 ] as const


### PR DESCRIPTION
### Description

Allows to use `--oxfmt` when creating a new project