### PR TITLE
feat: generate TypeScript projects by default

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -57,10 +57,6 @@ const FEATURE_FLAGS = [
 
 const FEATURE_OPTIONS = [
   {
-    value: 'typescript',
-    label: language.needsTypeScript.message,
-  },
-  {
     value: 'jsx',
     label: language.needsJsx.message,
   },
@@ -108,6 +104,7 @@ type PromptResult = {
   projectName?: string
   shouldOverwrite?: boolean
   packageName?: string
+  needsTypeScript?: boolean
   features?: (typeof FEATURE_OPTIONS)[number]['value'][]
   e2eFramework?: 'cypress' | 'nightwatch' | 'playwright'
   experimentFeatures?: (typeof EXPERIMENTAL_FEATURE_OPTIONS)[number]['value'][]
@@ -331,6 +328,13 @@ async function init() {
   }
 
   if (!isFeatureFlagsUsed) {
+    result.needsTypeScript = await unwrapPrompt(
+      confirm({
+        message: language.needsTypeScript.message,
+        initialValue: true,
+      }),
+    )
+
     result.features = await unwrapPrompt(
       multiselect({
         message: `${language.featureSelection.message} ${dim(language.featureSelection.hint)}`,
@@ -408,7 +412,7 @@ async function init() {
 
   const { features, experimentFeatures, needsBareboneTemplates } = result
 
-  const needsTypeScript = argv.ts || argv.typescript || features.includes('typescript')
+  const needsTypeScript = argv.ts || argv.typescript || result.needsTypeScript
   const needsJsx = argv.jsx || features.includes('jsx')
   const needsRouter = argv.router || argv['vue-router'] || features.includes('router')
   const needsPinia = argv.pinia || features.includes('pinia')

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -19,7 +19,7 @@
     "hint": "(↑/↓ to navigate, space to select, a to toggle all, enter to confirm)"
   },
   "needsTypeScript": {
-    "message": "TypeScript"
+    "message": "Use TypeScript?"
   },
   "needsJsx": {
     "message": "JSX Support"

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -19,7 +19,7 @@
     "hint": "(↑/↓ pour naviguer, espace pour sélectionner, a pour tout sélectionner, entrée pour confirmer)"
   },
   "needsTypeScript": {
-    "message": "TypeScript"
+    "message": "Utiliser TypeScript\u00a0?"
   },
   "needsJsx": {
     "message": "Support de JSX"

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -19,7 +19,7 @@
     "hint": "(↑/↓ gezinmek için, boşluk seçmek için, a tümünü seçmek için, enter onaylamak için)"
   },
   "needsTypeScript": {
-    "message": "TypeScript"
+    "message": "TypeScript kullanılsın mı?"
   },
   "needsJsx": {
     "message": "JSX Desteği"

--- a/locales/zh-Hans.json
+++ b/locales/zh-Hans.json
@@ -19,7 +19,7 @@
     "hint": "(↑/↓ 切换，空格选择，a 全选，回车确认)"
   },
   "needsTypeScript": {
-    "message": "TypeScript"
+    "message": "是否使用 TypeScript 语法？"
   },
   "needsJsx": {
     "message": "JSX 支持"

--- a/locales/zh-Hant.json
+++ b/locales/zh-Hant.json
@@ -19,7 +19,7 @@
     "hint": "(↑/↓ 切換，空格選擇，a 全選，enter 確認)"
   },
   "needsTypeScript": {
-    "message": "TypeScript"
+    "message": "是否使用 TypeScript？"
   },
   "needsJsx": {
     "message": "JSX 支援"


### PR DESCRIPTION
Closes #849

I separated the TypeScript prompt from the feature selection because the UI is quite confusing when the first option of a multiselect is selected by default, and there is no easy way to distinguish the selected state from the focus state at first glance.