### PR TITLE
feat: add Vue Router 5 typed routes for TypeScript projects

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -456,6 +456,9 @@ async function init() {
   if (needsRouter) {
     render('config/router')
   }
+  if (needsRouter && needsTypeScript) {
+    render('config/router-typed')
+  }
   if (needsPinia) {
     render('config/pinia')
   }
@@ -516,6 +519,30 @@ async function init() {
       JSON.stringify(rootTsConfig, null, 2) + '\n',
       'utf-8',
     )
+
+    // Add typed routes configuration to tsconfig.app.json when using Vue Router
+    if (needsRouter) {
+      const tsconfigAppPath = path.resolve(root, 'tsconfig.app.json')
+      const tsconfigApp = JSON.parse(fs.readFileSync(tsconfigAppPath, 'utf-8'))
+
+      // Include the generated typed-router.d.ts
+      tsconfigApp.include = tsconfigApp.include || []
+      tsconfigApp.include.push('typed-router.d.ts')
+
+      // rootDir is needed for the volar plugin
+      tsconfigApp.compilerOptions = tsconfigApp.compilerOptions || {}
+      tsconfigApp.compilerOptions.rootDir = '.'
+
+      // Add volar plugins for automatic useRoute() typing based on file location
+      tsconfigApp.vueCompilerOptions = {
+        plugins: [
+          'vue-router/volar/sfc-typed-router',
+          'vue-router/volar/sfc-route-blocks',
+        ],
+      }
+
+      fs.writeFileSync(tsconfigAppPath, JSON.stringify(tsconfigApp, null, 2) + '\n', 'utf-8')
+    }
   }
 
   // Render ESLint config

--- a/template/config/router-typed/_gitignore
+++ b/template/config/router-typed/_gitignore
@@ -1,0 +1,3 @@
+
+# Vue Router generated types
+typed-router.d.ts

--- a/template/config/router-typed/vite.config.js.data.mjs
+++ b/template/config/router-typed/vite.config.js.data.mjs
@@ -1,0 +1,13 @@
+export default function getData({ oldData }) {
+  const vueRouterPlugin = {
+    id: 'vue-router',
+    importer: "import vueRouter from 'vue-router/vite'",
+    initializer: 'vueRouter()',
+  }
+
+  return {
+    ...oldData,
+    // Prepend the vueRouter plugin before vue so that it can process route blocks
+    plugins: [vueRouterPlugin, ...oldData.plugins],
+  }
+}


### PR DESCRIPTION
## Summary

Closes #920

When both TypeScript and Vue Router are selected, the scaffolded project now includes Vue Router 5's typed routes configuration out of the box:

- Adds `vueRouter()` from `vue-router/vite` as a Vite plugin (using lowercase naming per Vite conventions)
- Configures `tsconfig.app.json` with `typed-router.d.ts` include, `rootDir`, and Volar plugins (`sfc-typed-router`, `sfc-route-blocks`)
- Adds `typed-router.d.ts` to `.gitignore` (generated file)

This does **not** add file-based/auto routes — it only enables typed routes for the existing manual route definitions, as discussed in the issue.

Non-TypeScript router projects are unaffected.

### Generated output (TypeScript + Router)

**vite.config.ts** gains:
```ts
import vueRouter from 'vue-router/vite'
// ...
plugins: [vueRouter(), vue(), vueDevTools()]
```

**tsconfig.app.json** gains:
```json
{
  "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "typed-router.d.ts"],
  "compilerOptions": { "rootDir": "." },
  "vueCompilerOptions": {
    "plugins": ["vue-router/volar/sfc-typed-router", "vue-router/volar/sfc-route-blocks"]
  }
}
```

## Test plan

- [ ] Run `pnpm run snapshot` and verify TypeScript + Router snapshots include the new vite plugin and tsconfig changes
- [ ] Run `pnpm run test` to confirm existing tests pass
- [ ] Scaffold a project with `--typescript --router` and verify typed routes work
- [ ] Scaffold a project with `--router` (no TS) and verify it's unaffected