### PR TITLE
fix(cypress-ts): remove workaround for TS6

### DIFF
--- a/template/tsconfig/cypress/cypress/tsconfig.json
+++ b/template/tsconfig/cypress/cypress/tsconfig.json
@@ -4,10 +4,6 @@
   "exclude": ["./support/component.*"],
   "compilerOptions": {
     "isolatedModules": false,
-    "types": ["cypress"],
-
-    // FIXME: Remove this when Cypress officially supports TypeScript 6.0
-    // https://github.com/cypress-io/cypress/issues/33511
-    "ignoreDeprecations": "6.0"
+    "types": ["cypress"]
   }
 }


### PR DESCRIPTION
Cypress 15.4.0 should have fully supported TypeScript 6