### PR TITLE
fix: quote glob in package script

### DIFF
--- a/template/linting/oxlint/package.json
+++ b/template/linting/oxlint/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "lint:oxlint": "oxlint . --fix",
     "lint:eslint": "eslint . --fix --cache",
-    "lint": "run-s lint:*"
+    "lint": "run-s 'lint:*'"
   },
   "devDependencies": {
     "eslint-plugin-oxlint": "~1.63.0",

--- a/template/linting/oxlint/package.json
+++ b/template/linting/oxlint/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "lint:oxlint": "oxlint . --fix",
     "lint:eslint": "eslint . --fix --cache",
-    "lint": "run-s 'lint:*'"
+    "lint": "run-s \"lint:*\""
   },
   "devDependencies": {
     "eslint-plugin-oxlint": "~1.63.0",


### PR DESCRIPTION
### Description

When using oxlint, the `lint` script in the generated `package.json` contains a `*` that may be expanded by the shell and can lead to unexpected behavior

This PR wraps the arg in quotes to stop shells from expanding it as a glob

This should fix #951, but I can't confirm right now

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->
