### PR TITLE
chore(ci): set explicit least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add an explicit `permissions` block to the main CI workflow
- set `contents: read` to follow least-privilege defaults for `GITHUB_TOKEN`
- keep current CI behavior unchanged while reducing token scope risk

## Why
GitHub Actions defaults can be broader than needed. Making permissions explicit improves security posture and keeps future permission changes intentional and reviewable.