### PR TITLE
chore: add a missing trailing comma in vite config template

### DIFF
--- a/template/base/vite.config.js.ejs
+++ b/template/base/vite.config.js.ejs
@@ -14,7 +14,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
### Description

Add one missing trailing comma in `vite.config.ts` file template.