### PR TITLE
fix: enable TypeScript with default flag

### DIFF
--- a/__test__/resolveFeatures.spec.ts
+++ b/__test__/resolveFeatures.spec.ts
@@ -1,0 +1,13 @@
+import { it, describe, expect } from 'vite-plus/test'
+import { resolveNeedsTypeScript } from '../utils/resolveFeatures'
+
+describe('resolveNeedsTypeScript', () => {
+  it('should enable TypeScript for the default feature flag', () => {
+    expect(resolveNeedsTypeScript({ default: true })).toBe(true)
+  })
+
+  it('should use the interactive prompt result when no TypeScript feature flag is set', () => {
+    expect(resolveNeedsTypeScript({}, true)).toBe(true)
+    expect(resolveNeedsTypeScript({}, false)).toBe(false)
+  })
+})

--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,7 @@ import {
   getPackageManagerOptions,
   type PackageManager,
 } from './utils/packageManager'
+import { resolveNeedsTypeScript } from './utils/resolveFeatures'
 
 import cliPackageJson from './package.json' with { type: 'json' }
 
@@ -391,7 +392,7 @@ async function init() {
 
   const { features, experimentFeatures, needsBareboneTemplates } = result
 
-  const needsTypeScript = argv.ts || argv.typescript || result.needsTypeScript
+  const needsTypeScript = resolveNeedsTypeScript(argv, result.needsTypeScript)
   const needsJsx = argv.jsx || features.includes('jsx')
   const needsRouter = argv.router || argv['vue-router'] || features.includes('router')
   const needsPinia = argv.pinia || features.includes('pinia')

--- a/utils/resolveFeatures.ts
+++ b/utils/resolveFeatures.ts
@@ -1,0 +1,12 @@
+type TypeScriptFeatureFlags = {
+  default?: boolean
+  ts?: boolean
+  typescript?: boolean
+}
+
+export function resolveNeedsTypeScript(
+  argv: TypeScriptFeatureFlags,
+  promptedNeedsTypeScript?: boolean,
+) {
+  return Boolean(argv.default || argv.ts || argv.typescript || promptedNeedsTypeScript)
+}


### PR DESCRIPTION
## Description

This keeps --default coherent with 0132289c26aaa32e7e58a27d9f85bc7adaf5920b, which enabled TypeScript in the prompt by default.
