### PR TITLE
feat: detect nub package manager

### DIFF
--- a/utils/applyVueBeta.ts
+++ b/utils/applyVueBeta.ts
@@ -30,6 +30,7 @@ function generateOverridesMap(): Record<string, string> {
  * - npm/bun: uses `overrides` field in package.json
  * - yarn: uses `resolutions` field in package.json
  * - pnpm: uses `overrides` and `peerDependencyRules` in pnpm-workspace.yaml
+ * - nub: uses the neutral `overrides` field in package.json
  */
 export default function applyVueBeta(
   root: string,
@@ -75,5 +76,15 @@ peerDependencyRules:
 `
 
     fs.writeFileSync(path.resolve(root, 'pnpm-workspace.yaml'), yamlContent, 'utf-8')
+  } else if (packageManager === 'nub') {
+    // nub is pnpm-CLI-compatible but reads project config only from neutral,
+    // cross-tool fields — not pnpm-named files like pnpm-workspace.yaml — so its
+    // overrides go in the `overrides` field in package.json. Unlike npm, nub does
+    // not require direct dependencies to be rewritten to match, so the override
+    // map alone is sufficient.
+    pkg.overrides = {
+      ...pkg.overrides,
+      ...overrides,
+    }
   }
 }

--- a/utils/getCommand.ts
+++ b/utils/getCommand.ts
@@ -9,16 +9,18 @@ export default function getCommand(
     return packageManager === 'yarn' ? 'yarn' : `${packageManager} install`
   }
   if (scriptName === 'build') {
-    return packageManager === 'npm' || packageManager === 'bun'
+    return packageManager === 'npm' || packageManager === 'bun' || packageManager === 'nub'
       ? `${packageManager} run build`
       : `${packageManager} build`
   }
 
   if (args) {
-    return packageManager === 'npm'
-      ? `npm run ${scriptName} -- ${args}`
+    return packageManager === 'npm' || packageManager === 'nub'
+      ? `${packageManager} run ${scriptName} -- ${args}`
       : `${packageManager} ${scriptName} ${args}`
   } else {
-    return packageManager === 'npm' ? `npm run ${scriptName}` : `${packageManager} ${scriptName}`
+    return packageManager === 'npm' || packageManager === 'nub'
+      ? `${packageManager} run ${scriptName}`
+      : `${packageManager} ${scriptName}`
   }
 }

--- a/utils/packageManager.ts
+++ b/utils/packageManager.ts
@@ -1,4 +1,4 @@
-export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun'
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'nub'
 
 /**
  * Infers the package manager from the user agent string.
@@ -10,6 +10,7 @@ export function inferPackageManager(): PackageManager {
   if (/pnpm/.test(userAgent)) return 'pnpm'
   if (/yarn/.test(userAgent)) return 'yarn'
   if (/bun/.test(userAgent)) return 'bun'
+  if (/nub/.test(userAgent)) return 'nub'
 
   return 'npm'
 }
@@ -18,6 +19,6 @@ export function inferPackageManager(): PackageManager {
  * Creates an ordered list of package managers with the preferred one first.
  */
 export function getPackageManagerOptions(preferred: PackageManager) {
-  const all: PackageManager[] = ['npm', 'pnpm', 'yarn', 'bun']
+  const all: PackageManager[] = ['npm', 'pnpm', 'yarn', 'bun', 'nub']
   return [preferred, ...all.filter((pm) => pm !== preferred)]
 }


### PR DESCRIPTION
When invoked through nub, create-vue misdetects the package manager as npm. It infers the PM from `npm_config_user_agent` in `utils/packageManager.ts` and falls back to npm; [nub](https://nubjs.com) advertises `nub/<version>`, so it isn't matched.

nub is a Rust CLI with a pnpm-compatible command grammar. This adds it to `inferPackageManager` and the options list, and routes it through the `run`-prefixed form in `getCommand` — nub requires an explicit `nub run <script>` and has no implicit script shortcut — yielding `nub install` and `nub run dev`.
