### PR TITLE
chore(lint): disable no-useless-default-assignment rule

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
     categories: {
       correctness: 'error',
     },
+    rules: {
+      // This type-aware rule requires strictNullChecks, but the repo sets
+      // `"strict": false` in tsconfig.json (the code relies on evolving array
+      // inference), so the rule cannot function here.
+      'typescript/no-useless-default-assignment': 'off',
+    },
     ignorePatterns: ['playground/**', 'template/**'],
     options: {
       typeAware: true,


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->
The type-aware rule requires strictNullChecks, but the repo sets "strict": false in tsconfig.json (the code relies on evolving array inference), so the rule errors on every file and cannot function here.