### PR TITLE
feat: add tsgo option to replace TypeScript with typescript-native-bridge

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,7 @@ import generateReadme from './utils/generateReadme'
 import getCommand from './utils/getCommand'
 import getLanguage from './utils/getLanguage'
 import { trimBoilerplate, removeCSSImport, emptyRouterConfig } from './utils/trimBoilerplate'
-import applyVueRc from './utils/applyVueRc'
+import applyOverrides from './utils/applyOverrides'
 import {
   inferPackageManager,
   getPackageManagerOptions,
@@ -54,6 +54,7 @@ const FEATURE_FLAGS = [
   'vue-rc',
   // Kept as a compatibility alias for the former Vue 3.6 beta feature.
   'vue-beta',
+  'tsgo',
 ] as const
 
 const FEATURE_OPTIONS = [
@@ -94,6 +95,10 @@ const EXPERIMENTAL_FEATURE_OPTIONS = [
   {
     value: 'vue-rc',
     label: language.needsVueRc.message,
+  },
+  {
+    value: 'tsgo',
+    label: language.needsTsgo.message,
   },
 ] as const
 
@@ -203,6 +208,9 @@ Available feature flags:
     Add Oxfmt for code formatting.
   --vue-rc
     Use Vue 3.6 Release Candidate. Requires specifying a package manager in interactive mode.
+  --tsgo
+    Replace TypeScript with typescript-native-bridge (tsgo). Requires ${cyan('--typescript')}.
+    Requires specifying a package manager in interactive mode.
 
 Unstable feature flags:
   --tests, --with-tests
@@ -355,17 +363,24 @@ async function init() {
         }),
       )
     }
+    // tsgo replaces TypeScript, so it's only offered when TypeScript is enabled
+    const experimentalFeatureOptions = result.needsTypeScript
+      ? EXPERIMENTAL_FEATURE_OPTIONS
+      : EXPERIMENTAL_FEATURE_OPTIONS.filter(({ value }) => value !== 'tsgo')
     result.experimentFeatures = await unwrapPrompt(
       multiselect({
         message: `${language.needsExperimentalFeatures.message} ${dim(language.needsExperimentalFeatures.hint)}`,
         // @ts-expect-error @clack/prompt's type doesn't support readonly array yet
-        options: EXPERIMENTAL_FEATURE_OPTIONS,
+        options: experimentalFeatureOptions,
         required: false,
       }),
     )
 
-    // Ask for package manager if Vue 3.6 RC is selected (needed for correct overrides)
-    if (result.experimentFeatures.includes('vue-rc')) {
+    // Ask for package manager if Vue 3.6 RC or tsgo is selected (needed for correct overrides)
+    if (
+      result.experimentFeatures.includes('vue-rc') ||
+      result.experimentFeatures.includes('tsgo')
+    ) {
       const packageManagerOptions = getPackageManagerOptions(inferredPackageManager).map((pm) => ({
         value: pm,
         label: pm,
@@ -404,6 +419,8 @@ async function init() {
     argv.prettier || argv['eslint-with-prettier'] || features.includes('prettier')
   const needsOxfmt = experimentFeatures.includes('oxfmt') || argv['oxfmt']
   const needsVueRc = experimentFeatures.includes('vue-rc') || argv['vue-rc'] || argv['vue-beta']
+  // tsgo replaces the `typescript` package, so it only makes sense with TypeScript enabled
+  const needsTsgo = needsTypeScript && (experimentFeatures.includes('tsgo') || argv.tsgo)
 
   const { e2eFramework } = result
   const needsCypress =
@@ -655,14 +672,14 @@ async function init() {
     }
   }
 
-  // Use the package manager selected by user for Vue 3.6 RC, or inferred from user agent
+  // Use the package manager selected by user for the version overrides, or inferred from user agent
   const packageManager = result.packageManager ?? inferredPackageManager
 
-  // Apply Vue 3.6 release candidate overrides if the feature is enabled
-  if (needsVueRc) {
+  // Apply version overrides for experimental features (Vue 3.6 RC, tsgo) if enabled
+  if (needsVueRc || needsTsgo) {
     const pkgPath = path.resolve(root, 'package.json')
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
-    applyVueRc(root, packageManager, pkg)
+    applyOverrides(root, packageManager, pkg, { vueRc: needsVueRc, tsgo: needsTsgo })
     fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
   }
 

--- a/index.ts
+++ b/index.ts
@@ -474,6 +474,9 @@ async function init() {
   }
   if (needsTypeScript) {
     render('config/typescript')
+    if (needsTsgo) {
+      render('config/tsgo')
+    }
 
     // Render tsconfigs
     render('tsconfig/base')
@@ -690,6 +693,7 @@ async function init() {
       projectName: result.projectName ?? result.packageName ?? defaultProjectName,
       packageManager,
       needsTypeScript,
+      needsTsgo,
       needsVitest,
       needsCypress,
       needsPlaywright,

--- a/index.ts
+++ b/index.ts
@@ -713,6 +713,12 @@ async function init() {
   }
   outroMessage += `   ${bold(green(getCommand(packageManager, 'dev')))}\n`
 
+  if (needsTsgo && packageManager === 'nub') {
+    outroMessage += `
+${dim('|')} ${language.warnings.tsgoNubReleaseAge}
+`
+  }
+
   if (!dotGitDirectoryState.hasDotGitDirectory) {
     outroMessage += `
 ${dim('|')} ${language.infos.optionalGitCommand}

--- a/index.ts
+++ b/index.ts
@@ -209,7 +209,7 @@ Available feature flags:
   --vue-rc
     Use Vue 3.6 Release Candidate. Requires specifying a package manager in interactive mode.
   --tsgo
-    Replace TypeScript with typescript-native-bridge (tsgo). Requires ${cyan('--typescript')}.
+    Add TypeScript support using typescript-native-bridge (tsgo).
     Requires specifying a package manager in interactive mode.
 
 Unstable feature flags:

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -64,6 +64,9 @@
   "needsVueRc": {
     "message": "Vue 3.6 (Release Candidate)"
   },
+  "needsTsgo": {
+    "message": "Replace TypeScript with typescript-native-bridge (tsgo)"
+  },
   "needsOxfmt": {
     "message": "Replace Prettier with Oxfmt"
   },

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -80,6 +80,9 @@
   "errors": {
     "operationCancelled": "Operation cancelled"
   },
+  "warnings": {
+    "tsgoNubReleaseAge": "Nub's default 24-hour cooling window may temporarily prevent installing a newly published typescript-native-bridge version. Learn more: https://nubjs.com/docs/install#cooling-window"
+  },
   "defaultToggleOptions": {
     "active": "Yes",
     "inactive": "No"

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -75,7 +75,7 @@
   },
   "packageManagerSelection": {
     "message": "Which package manager will you use?",
-    "hint": "(Vue 3.6 Release Candidate requires version overrides that differ per package manager)"
+    "hint": "(Selected experimental features require version overrides that differ per package manager)"
   },
   "errors": {
     "operationCancelled": "Operation cancelled"

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -64,6 +64,9 @@
   "needsVueRc": {
     "message": "Vue 3.6 (version candidate)"
   },
+  "needsTsgo": {
+    "message": "Remplacer TypeScript par typescript-native-bridge (tsgo)"
+  },
   "needsOxfmt": {
     "message": "Remplacer Prettier par Oxfmt"
   },

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -80,6 +80,9 @@
   "errors": {
     "operationCancelled": "Operation annulée"
   },
+  "warnings": {
+    "tsgoNubReleaseAge": "La période d’attente de 24 heures appliquée par défaut par Nub peut temporairement empêcher l’installation d’une version de typescript-native-bridge récemment publiée. En savoir plus : https://nubjs.com/docs/install#cooling-window"
+  },
   "defaultToggleOptions": {
     "active": "Oui",
     "inactive": "Non"

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -75,7 +75,7 @@
   },
   "packageManagerSelection": {
     "message": "Quel gestionnaire de paquets allez-vous utiliser\u00a0?",
-    "hint": "(La version candidate de Vue 3.6 nécessite de forcer certaines versions différemment selon le gestionnaire de paquets)"
+    "hint": "(Les fonctionnalités expérimentales sélectionnées nécessitent de forcer certaines versions différemment selon le gestionnaire de paquets)"
   },
   "errors": {
     "operationCancelled": "Operation annulée"

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -64,6 +64,9 @@
   "needsVueRc": {
     "message": "Vue 3.6 (sürüm adayı)"
   },
+  "needsTsgo": {
+    "message": "TypeScript'i typescript-native-bridge (tsgo) ile değiştir"
+  },
   "needsOxfmt": {
     "message": "Prettier'ı Oxfmt ile değiştir"
   },

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -80,6 +80,9 @@
   "errors": {
     "operationCancelled": "İşlem iptal edildi"
   },
+  "warnings": {
+    "tsgoNubReleaseAge": "Nub'ın varsayılan 24 saatlik bekleme süresi, yeni yayımlanan bir typescript-native-bridge sürümünün yüklenmesini geçici olarak engelleyebilir. Daha fazla bilgi: https://nubjs.com/docs/install#cooling-window"
+  },
   "defaultToggleOptions": {
     "active": "Evet",
     "inactive": "Hayır"

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -75,7 +75,7 @@
   },
   "packageManagerSelection": {
     "message": "Hangi paket yöneticisini kullanacaksınız?",
-    "hint": "(Vue 3.6 sürüm adayı, paket yöneticisine özgü sürüm geçersiz kılmaları gerektirir)"
+    "hint": "(Seçilen deneysel özellikler paket yöneticisine özgü sürüm geçersiz kılmaları gerektirir)"
   },
   "errors": {
     "operationCancelled": "İşlem iptal edildi"

--- a/locales/zh-Hans.json
+++ b/locales/zh-Hans.json
@@ -64,6 +64,9 @@
   "needsVueRc": {
     "message": "Vue 3.6（发布候选版）"
   },
+  "needsTsgo": {
+    "message": "使用 typescript-native-bridge（tsgo）替代 TypeScript"
+  },
   "needsOxfmt": {
     "message": "使用 Oxfmt 替代 Prettier"
   },

--- a/locales/zh-Hans.json
+++ b/locales/zh-Hans.json
@@ -80,6 +80,9 @@
   "errors": {
     "operationCancelled": "操作取消"
   },
+  "warnings": {
+    "tsgoNubReleaseAge": "Nub 默认的 24 小时发布冷却期可能会暂时阻止安装刚发布的 typescript-native-bridge 版本。了解详情：https://nubjs.com/docs/install#cooling-window"
+  },
   "defaultToggleOptions": {
     "active": "是",
     "inactive": "否"

--- a/locales/zh-Hans.json
+++ b/locales/zh-Hans.json
@@ -75,7 +75,7 @@
   },
   "packageManagerSelection": {
     "message": "项目将使用哪个包管理器？",
-    "hint": "（需要根据包管理器生成对应的 Vue 3.6 发布候选版配置）"
+    "hint": "（所选试验特性需要根据包管理器使用不同的版本覆盖配置）"
   },
   "errors": {
     "operationCancelled": "操作取消"

--- a/locales/zh-Hant.json
+++ b/locales/zh-Hant.json
@@ -64,6 +64,9 @@
   "needsVueRc": {
     "message": "Vue 3.6（發行候選版本）"
   },
+  "needsTsgo": {
+    "message": "使用 typescript-native-bridge（tsgo）替代 TypeScript"
+  },
   "needsOxfmt": {
     "message": "使用 Oxfmt 替代 Prettier"
   },

--- a/locales/zh-Hant.json
+++ b/locales/zh-Hant.json
@@ -80,6 +80,9 @@
   "errors": {
     "operationCancelled": "操作取消"
   },
+  "warnings": {
+    "tsgoNubReleaseAge": "Nub 預設的 24 小時發布冷卻期可能會暫時阻止安裝剛發布的 typescript-native-bridge 版本。瞭解詳情：https://nubjs.com/docs/install#cooling-window"
+  },
   "defaultToggleOptions": {
     "active": "是",
     "inactive": "否"

--- a/locales/zh-Hant.json
+++ b/locales/zh-Hant.json
@@ -75,7 +75,7 @@
   },
   "packageManagerSelection": {
     "message": "專案將使用哪個套件管理器？",
-    "hint": "（需要根據套件管理器生成對應的 Vue 3.6 發行候選版本配置）"
+    "hint": "（所選試驗特性需要根據套件管理器使用不同的版本覆寫配置）"
   },
   "errors": {
     "operationCancelled": "操作取消"

--- a/template/config/tsgo/.vscode/settings.json
+++ b/template/config/tsgo/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true
+}

--- a/template/config/tsgo/_gitignore
+++ b/template/config/tsgo/_gitignore
@@ -1,0 +1,1 @@
+!.vscode/settings.json

--- a/utils/applyOverrides.ts
+++ b/utils/applyOverrides.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import type { PackageManager } from './packageManager'
 
-// Core Vue packages that need to be overridden
+// Core Vue packages that need to be overridden for the Vue 3.6 RC
 // Based on https://github.com/haoqunjiang/install-vue/blob/main/src/constants.ts
 const CORE_VUE_PACKAGES = [
   'vue',
@@ -20,44 +20,69 @@ const CORE_VUE_PACKAGES = [
   '@vue/compat',
 ] as const
 
-function generateOverridesMap(): Record<string, string> {
-  return Object.fromEntries(CORE_VUE_PACKAGES.map((name) => [name, 'rc']))
+// https://github.com/johnsoncodehk/typescript-native-bridge
+// A drop-in `typescript` replacement backed by tsgo (the Go engine of TypeScript 7),
+// which keeps the classic `typescript` API surface so that vue-tsc, typescript-eslint,
+// and tsserver plugins keep working.
+const TSGO_SPEC = 'npm:typescript-native-bridge@latest'
+
+export type OverrideFeatures = {
+  vueRc?: boolean
+  tsgo?: boolean
 }
 
 /**
- * Apply Vue 3.6 release candidate overrides to the project based on the package manager.
+ * Apply version overrides for experimental features to the project,
+ * based on the package manager.
  * Different package managers have different mechanisms for version overrides:
  * - npm/bun: uses `overrides` field in package.json
  * - yarn: uses `resolutions` field in package.json
  * - pnpm: uses `overrides` and `peerDependencyRules` in pnpm-workspace.yaml
  * - nub: uses the neutral `overrides` field in package.json
  */
-export default function applyVueRc(
+export default function applyOverrides(
   root: string,
   packageManager: PackageManager,
   pkg: Record<string, any>,
+  { vueRc = false, tsgo = false }: OverrideFeatures,
 ): void {
-  const overrides = generateOverridesMap()
+  const overrides: Record<string, string> = {}
+  if (vueRc) {
+    for (const name of CORE_VUE_PACKAGES) {
+      overrides[name] = 'rc'
+    }
+  }
 
   if (packageManager === 'npm' || packageManager === 'bun') {
     // https://github.com/npm/rfcs/blob/main/accepted/0036-overrides.md
     // NPM overrides require exact versions for resolution, but the "rc" dist-tag works too
     // Bun also supports the same `overrides` field
+    if (tsgo) {
+      // Putting an `npm:` alias directly inside `overrides` is rejected or
+      // mis-resolved by some npm versions, so the alias goes on the direct
+      // dependency and the override references it via "$typescript".
+      // https://github.com/johnsoncodehk/typescript-native-bridge (issue #8)
+      overrides['typescript'] = '$typescript'
+    }
     pkg.overrides = {
       ...pkg.overrides,
       ...overrides,
     }
 
     // NPM requires direct dependencies to be rewritten to match overrides
-    for (const dependencyName of CORE_VUE_PACKAGES) {
+    for (const dependencyName of Object.keys(overrides)) {
       for (const dependencyType of ['dependencies', 'devDependencies', 'optionalDependencies']) {
         if (pkg[dependencyType]?.[dependencyName]) {
-          pkg[dependencyType][dependencyName] = overrides[dependencyName]
+          pkg[dependencyType][dependencyName] =
+            dependencyName === 'typescript' ? TSGO_SPEC : overrides[dependencyName]
         }
       }
     }
   } else if (packageManager === 'yarn') {
     // https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-selective-versions-resolutions.md
+    if (tsgo) {
+      overrides['typescript'] = TSGO_SPEC
+    }
     pkg.resolutions = {
       ...pkg.resolutions,
       ...overrides,
@@ -65,15 +90,22 @@ export default function applyVueRc(
   } else if (packageManager === 'pnpm') {
     // pnpm now recommends putting overrides in pnpm-workspace.yaml
     // https://pnpm.io/pnpm-workspace_yaml
-    const yamlContent = `overrides:
+    if (tsgo) {
+      overrides['typescript'] = TSGO_SPEC
+    }
+    let yamlContent = `overrides:
 ${Object.entries(overrides)
   .map(([key, value]) => `  '${key}': '${value}'`)
   .join('\n')}
+`
 
+    if (vueRc) {
+      yamlContent += `
 peerDependencyRules:
   allowAny:
     - 'vue'
 `
+    }
 
     fs.writeFileSync(path.resolve(root, 'pnpm-workspace.yaml'), yamlContent, 'utf-8')
   } else if (packageManager === 'nub') {
@@ -82,6 +114,9 @@ peerDependencyRules:
     // overrides go in the `overrides` field in package.json. Unlike npm, nub does
     // not require direct dependencies to be rewritten to match, so the override
     // map alone is sufficient.
+    if (tsgo) {
+      overrides['typescript'] = TSGO_SPEC
+    }
     pkg.overrides = {
       ...pkg.overrides,
       ...overrides,

--- a/utils/generateReadme.ts
+++ b/utils/generateReadme.ts
@@ -8,10 +8,17 @@ const sfcTypeSupportDoc = [
   '',
 ].join('\n')
 
+const tsgoEditorSupportDoc = [
+  '',
+  'This project replaces its workspace TypeScript package with [typescript-native-bridge](https://github.com/johnsoncodehk/typescript-native-bridge). Command-line tools use the bridge automatically. To use it in VS Code after installing dependencies, accept the prompt to use the workspace TypeScript version. If the prompt does not appear, run **TypeScript: Select TypeScript Version** and choose **Use Workspace Version**.',
+  '',
+].join('\n')
+
 export default function generateReadme({
   projectName,
   packageManager,
   needsTypeScript,
+  needsTsgo,
   needsCypress,
   needsCypressCT,
   needsPlaywright,
@@ -28,7 +35,7 @@ This template should help get you started developing with Vue 3 in Vite.
 ## Recommended IDE Setup
 
 [VS Code](https://code.visualstudio.com/) + [Vue (Official)](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur).
-
+${needsTsgo ? tsgoEditorSupportDoc : ''}
 ## Recommended Browser Setup
 
 - Chromium-based browsers (Chrome, Edge, Brave, etc.):

--- a/utils/getLanguage.ts
+++ b/utils/getLanguage.ts
@@ -39,6 +39,7 @@ interface Language {
   needsExperimental: LanguageItem
   needsExperimentalFeatures: LanguageItem
   needsVueRc: LanguageItem
+  needsTsgo: LanguageItem
   needsOxfmt: LanguageItem
   needsBareboneTemplates: LanguageItem
   packageManagerSelection: LanguageItem

--- a/utils/getLanguage.ts
+++ b/utils/getLanguage.ts
@@ -46,6 +46,9 @@ interface Language {
   errors: {
     operationCancelled: string
   }
+  warnings: {
+    tsgoNubReleaseAge: string
+  }
   defaultToggleOptions: {
     active: string
     inactive: string

--- a/utils/resolveFeatures.ts
+++ b/utils/resolveFeatures.ts
@@ -9,7 +9,5 @@ export function resolveNeedsTypeScript(
   argv: TypeScriptFeatureFlags,
   promptedNeedsTypeScript?: boolean,
 ) {
-  return Boolean(
-    argv.default || argv.ts || argv.typescript || argv.tsgo || promptedNeedsTypeScript,
-  )
+  return Boolean(argv.default || argv.ts || argv.typescript || argv.tsgo || promptedNeedsTypeScript)
 }

--- a/utils/resolveFeatures.ts
+++ b/utils/resolveFeatures.ts
@@ -2,11 +2,14 @@ type TypeScriptFeatureFlags = {
   default?: boolean
   ts?: boolean
   typescript?: boolean
+  tsgo?: boolean
 }
 
 export function resolveNeedsTypeScript(
   argv: TypeScriptFeatureFlags,
   promptedNeedsTypeScript?: boolean,
 ) {
-  return Boolean(argv.default || argv.ts || argv.typescript || promptedNeedsTypeScript)
+  return Boolean(
+    argv.default || argv.ts || argv.typescript || argv.tsgo || promptedNeedsTypeScript,
+  )
 }


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vuejs/create-vue/blob/main/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem. If you find a duplicate, please help us reviewing it.
- Include relevant tests.

Thank you for contributing to create-vue!
----------------------------------------------------------------------->
Add a new experimental feature (--tsgo) that overrides the typescript package with typescript-native-bridge. This tsgo-backed drop-in replacement preserves the classic typescript API surface, so vue-tsc, typescript-eslint, and tsserver plugins continue to work.

https://github.com/johnsoncodehk/typescript-native-bridge