### PR TITLE
fix: clarify that the overwrite prompt deletes all existing files

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -8,7 +8,7 @@
       "current": "Current directory",
       "target": "Target directory"
     },
-    "message": "is not empty. Remove existing files and continue"
+    "message": "is not empty. Remove all existing files and continue?"
   },
   "packageName": {
     "message": "Package name:",


### PR DESCRIPTION
### Description

The confirm prompt for a non-empty target directory reads "Remove existing files and continue". Without a question mark it looks like an instruction telling the user to clear the folder first, not a question about what the CLI is about to do. In #1099 someone answered Yes on that reading and lost the contents of an existing project, including untracked files like `.env`.

This rewords it to "Remove all existing files and continue?", so it reads as a question and states that everything in the directory goes. The other locales already phrase it as a question.

Fixes #1099