### PR TITLE
feat: add standard script aliases

### DIFF
--- a/__test__/packageScripts.spec.ts
+++ b/__test__/packageScripts.spec.ts
@@ -1,0 +1,73 @@
+import { it, describe, expect } from 'vite-plus/test'
+import { addStandardScriptAliases } from '../utils/packageScripts'
+
+describe('addStandardScriptAliases', () => {
+  it('adds start as an alias for dev', () => {
+    expect(
+      addStandardScriptAliases({
+        scripts: {
+          dev: 'vite',
+          build: 'vite build',
+        },
+      }),
+    ).toStrictEqual({
+      scripts: {
+        dev: 'vite',
+        start: 'vite',
+        build: 'vite build',
+      },
+    })
+  })
+
+  it('adds test as an alias for unit tests when unit and e2e tests exist', () => {
+    expect(
+      addStandardScriptAliases({
+        scripts: {
+          'test:unit': 'vitest',
+          'test:e2e': 'playwright test',
+        },
+      }),
+    ).toStrictEqual({
+      scripts: {
+        test: 'vitest',
+        'test:unit': 'vitest',
+        'test:e2e': 'playwright test',
+      },
+    })
+  })
+
+  it('adds test as an alias for e2e tests when only e2e tests exist', () => {
+    expect(
+      addStandardScriptAliases({
+        scripts: {
+          'test:e2e': 'playwright test',
+        },
+      }),
+    ).toStrictEqual({
+      scripts: {
+        test: 'playwright test',
+        'test:e2e': 'playwright test',
+      },
+    })
+  })
+
+  it('keeps existing standard scripts', () => {
+    expect(
+      addStandardScriptAliases({
+        scripts: {
+          dev: 'vite',
+          start: 'custom start',
+          test: 'custom test',
+          'test:unit': 'vitest',
+        },
+      }),
+    ).toStrictEqual({
+      scripts: {
+        dev: 'vite',
+        start: 'custom start',
+        test: 'custom test',
+        'test:unit': 'vitest',
+      },
+    })
+  })
+})

--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,7 @@ import {
   type PackageManager,
 } from './utils/packageManager'
 import { resolveNeedsTypeScript } from './utils/resolveFeatures'
+import { addStandardScriptAliases } from './utils/packageScripts'
 
 import cliPackageJson from './package.json' with { type: 'json' }
 
@@ -678,13 +679,19 @@ async function init() {
   // Use the package manager selected by user for the version overrides, or inferred from user agent
   const packageManager = result.packageManager ?? inferredPackageManager
 
+  const pkgPath = path.resolve(root, 'package.json')
+  const generatedPackageJson = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
+
   // Apply version overrides for experimental features (Vue 3.6 RC, tsgo) if enabled
   if (needsVueRc || needsTsgo) {
-    const pkgPath = path.resolve(root, 'package.json')
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
-    applyOverrides(root, packageManager, pkg, { vueRc: needsVueRc, tsgo: needsTsgo })
-    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
+    applyOverrides(root, packageManager, generatedPackageJson, {
+      vueRc: needsVueRc,
+      tsgo: needsTsgo,
+    })
   }
+
+  addStandardScriptAliases(generatedPackageJson)
+  fs.writeFileSync(pkgPath, JSON.stringify(generatedPackageJson, null, 2) + '\n')
 
   // README generation
   fs.writeFileSync(

--- a/utils/packageScripts.ts
+++ b/utils/packageScripts.ts
@@ -1,0 +1,62 @@
+type PackageJsonWithScripts = {
+  scripts?: Record<string, string>
+}
+
+function insertScript(
+  scripts: Record<string, string>,
+  key: string,
+  value: string,
+  { after, before }: { after?: string; before?: string },
+) {
+  if (key in scripts) {
+    return scripts
+  }
+
+  const result: Record<string, string> = {}
+  let inserted = false
+
+  for (const [scriptName, scriptValue] of Object.entries(scripts)) {
+    if (!inserted && before === scriptName) {
+      result[key] = value
+      inserted = true
+    }
+
+    result[scriptName] = scriptValue
+
+    if (!inserted && after === scriptName) {
+      result[key] = value
+      inserted = true
+    }
+  }
+
+  if (!inserted) {
+    result[key] = value
+  }
+
+  return result
+}
+
+export function addStandardScriptAliases<T extends PackageJsonWithScripts>(packageJson: T): T {
+  if (!packageJson.scripts) {
+    return packageJson
+  }
+
+  let scripts = packageJson.scripts
+
+  if (!('start' in scripts) && scripts.dev) {
+    scripts = insertScript(scripts, 'start', scripts.dev, { after: 'dev' })
+  }
+
+  if (!('test' in scripts)) {
+    const aliasedTestScript = 'test:unit' in scripts ? 'test:unit' : 'test:e2e'
+
+    if (scripts[aliasedTestScript]) {
+      scripts = insertScript(scripts, 'test', scripts[aliasedTestScript], {
+        before: aliasedTestScript,
+      })
+    }
+  }
+
+  packageJson.scripts = scripts
+  return packageJson
+}


### PR DESCRIPTION
### Description

Fixes #303.

Adds a final script-alias pass for generated `package.json` files:

- `start` mirrors `dev`
- `test` mirrors `test:unit` when unit tests are present
- `test` mirrors `test:e2e` for e2e-only projects
- existing `start` or `test` scripts are preserved

This keeps the existing `dev`, `test:unit`, and `test:e2e` commands for compatibility while adding the standard npm script names requested in the issue.

Validation:

- `pnpm install --frozen-lockfile --store-dir "D:\grand-final prr\.cache\pnpm-store-create-vue"`
- `pnpm run build`
- `pnpm run test:unit`
- `pnpm run format-check`
- `pnpm exec vp lint index.ts utils/packageScripts.ts __test__/packageScripts.spec.ts`
- `git diff --check`
- Generated sample projects with the built bundle for default, unit-only, e2e-only, unit+e2e, and Cypress-only combinations, then inspected their `scripts` output.

Note: the install command used command-scoped `COREPACK_HOME`, `PNPM_HOME`, `CYPRESS_CACHE_FOLDER`, `TEMP`, and `TMP` under `D:\grand-final prr\.cache` because this local machine's C: drive is full. I also attempted `pnpm run snapshot` after initializing `playground`, but it failed locally before generating templates with zx's `No quote function is defined` in this workspace path; the `playground` submodule was restored afterward and is intentionally not included, per CONTRIBUTING.md.