### PR TITLE
fix: keep Oxlint dependencies aligned

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>haoqunjiang/renovate-presets:npm.json5", "helpers:pinGitHubActionDigests"]
+  "extends": ["github>haoqunjiang/renovate-presets:npm.json5", "helpers:pinGitHubActionDigests"],
+  "packageRules": [
+    {
+      "description": "Update Oxlint and its ESLint plugin together",
+      "matchFileNames": ["template/linting/oxlint/package.json"],
+      "matchDepNames": ["oxlint", "eslint-plugin-oxlint"],
+      "groupName": "aligned oxlint packages",
+      "groupSingleUpdates": true,
+      "minimumGroupSize": 2
+    }
+  ]
 }


### PR DESCRIPTION
### Description

Require Renovate to update oxlint and eslint-plugin-oxlint together so their peer dependency ranges cannot drift independently.

Fixes #1120

@haoqunjiang let me know if you prefer to update your preset instead.
