### PR TITLE
ci: check peer dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         env:
           CYPRESS_INSTALL_BINARY: 0
           CHROMEDRIVER_SKIP_DOWNLOAD: true
+      - run: pnpm peers check
       - run: pnpm build
       - run: pnpm format-check
       - run: pnpm test:unit


### PR DESCRIPTION
### Description

Fail CI when the workspace lockfile contains missing or incompatible peer dependencies.

This would have caught #1120 
