### PR TITLE
fix: add extension to Vitest config import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
               build
           # ----- Vitest -----
           - name: 'test:unit (vitest)'
-            run: pnpm --filter '*vitest*' test:unit
+            run: node ../scripts/run-without-warnings.mjs pnpm --filter '*vitest*' exec vitest --run
           # ----- ESLint -----
           - name: 'lint:oxlint'
             run: pnpm --filter '*eslint*' lint:oxlint --max-warnings=0 -A no-empty-file

--- a/__test__/runWithoutWarnings.spec.ts
+++ b/__test__/runWithoutWarnings.spec.ts
@@ -1,0 +1,40 @@
+/// <reference types="node" />
+
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vite-plus/test'
+
+const runWithoutWarningsPath = fileURLToPath(
+  new URL('../scripts/run-without-warnings.mjs', import.meta.url),
+)
+
+function runWithoutWarnings(script: string) {
+  return spawnSync(
+    process.execPath,
+    [runWithoutWarningsPath, process.execPath, '--input-type=module', '--eval', script],
+    { encoding: 'utf8' },
+  )
+}
+
+describe('runWithoutWarnings', () => {
+  it('fails when a successful command writes a warning to stderr', () => {
+    const result = runWithoutWarnings("console.error('probe warning')")
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('probe warning')
+    expect(result.stderr).toContain('Command succeeded with warnings on stderr.')
+  })
+
+  it('passes when a successful command does not write to stderr', () => {
+    const result = runWithoutWarnings("console.log('clean output')")
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('clean output')
+  })
+
+  it('preserves the exit code of a failed command', () => {
+    const result = runWithoutWarnings('process.exit(2)')
+
+    expect(result.status).toBe(2)
+  })
+})

--- a/index.ts
+++ b/index.ts
@@ -462,6 +462,10 @@ async function init() {
   }
   if (needsVitest) {
     render('config/vitest')
+    callbacks.push(async (dataStore) => {
+      const vitestConfigPath = path.resolve(root, 'vitest.config.js')
+      dataStore[vitestConfigPath] = { needsTypeScript }
+    })
   }
   if (needsCypress) {
     render('config/cypress')

--- a/scripts/run-without-warnings.mjs
+++ b/scripts/run-without-warnings.mjs
@@ -1,0 +1,36 @@
+import { spawn } from 'node:child_process'
+
+const [command, ...args] = process.argv.slice(2)
+
+if (!command) {
+  throw new Error('A command is required.')
+}
+
+// Stream the command normally, but capture stderr so successful commands that
+// emit warnings can still make the CI job fail.
+const child = spawn(command, args, {
+  // Windows needs a shell to resolve pnpm's command shim.
+  shell: process.platform === 'win32' && command === 'pnpm',
+  stdio: ['inherit', 'inherit', 'pipe'],
+})
+
+let stderr = ''
+child.stderr.on('data', (chunk) => {
+  // Keep the original stderr visible while retaining it for the final check.
+  stderr += chunk
+  process.stderr.write(chunk)
+})
+
+const exitCode = await new Promise((resolve, reject) => {
+  child.on('error', reject)
+  child.on('close', resolve)
+})
+
+// Preserve real command failures; otherwise treat any stderr as a warning and
+// turn the successful exit into a failure.
+if (exitCode !== 0) {
+  process.exitCode = exitCode ?? 1
+} else if (stderr.trim()) {
+  console.error('Command succeeded with warnings on stderr.')
+  process.exitCode = 1
+}

--- a/template/config/vitest/vitest.config.js.ejs
+++ b/template/config/vitest/vitest.config.js.ejs
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import { mergeConfig, defineConfig, configDefaults } from 'vitest/config'
-import viteConfig from './vite.config'
+import viteConfig from './vite.config.<%= needsTypeScript ? 'ts' : 'js' %>'
 
 export default mergeConfig(
   viteConfig,

--- a/template/tsconfig/base/tsconfig.node.json
+++ b/template/tsconfig/base/tsconfig.node.json
@@ -13,6 +13,7 @@
     // Bundler mode provides a smoother developer experience.
     "module": "preserve",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
 
     // Include Node.js types and avoid accidentally including other `@types/*` packages.
     "types": ["node"],


### PR DESCRIPTION
## Summary

Fix the Vite native config-loader warning in projects generated with Vitest.

## Problem

Generated Vitest configs imported the Vite config without a file extension:

```js
import viteConfig from './vite.config'
```

Vite’s current loader accepts this, but its native config loader requires an explicit extension. Generated projects therefore emitted a warning and failed when using `configLoader: 'native'`.


## Fix

- Generate `./vite.config.ts` imports for TypeScript projects.
- Generate `./vite.config.js` imports for JavaScript projects.
- Enable `allowImportingTsExtensions` in the generated TypeScript Node configuration.
- Add a CI wrapper that fails successful Vitest runs when they emit warnings on stderr.


Related: https://github.com/vitejs/vite/issues/21546